### PR TITLE
Allow Operator to Be Namespace-Scoped

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,20 @@ By default, no service annotations will be applied to the Redis nor Sentinel ser
 
 In order to apply custom service Annotations, you can provide the `serviceAnnotations` option inside redis/sentinel spec. An example can be found in the [custom annotations example file](example/redisfailover/custom-annotations.yaml).
 
+### Allow Operator to Be Namespace-Scoped
+By default operator is cluster wide.
+
+In order to make operator namespace-scoped you can provide the env variable `WATCH_NAMESPACE` to the redisoperator deployment manifest.
+
+```
+env:
+  - name: WATCH_NAMESPACE
+    valueFrom:
+      fieldRef:
+        fieldPath: metadata.namespace
+```
+
+
 ### Control of label propagation.
 By default the operator will propagate all labels on the CRD down to the resources that it creates.  This can be problematic if the
 labels on the CRD are not fully under your own control (for example: being deployed by a gitops operator)

--- a/operator/redisfailover/factory.go
+++ b/operator/redisfailover/factory.go
@@ -34,14 +34,8 @@ func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lo
 	rfService := rfservice.NewRedisFailoverKubeClient(k8sService, logger, kooperMetricsRecorder)
 	rfChecker := rfservice.NewRedisFailoverChecker(k8sService, redisClient, logger, kooperMetricsRecorder)
 	rfHealer := rfservice.NewRedisFailoverHealer(k8sService, redisClient, logger)
-
-	opType := os.Getenv("OP_TYPE")
-	opNamespace := ""
-
-	if opType == "namespaced" {
-		opNamespace = lockNamespace
-	}
-
+	opNamespace := os.Getenv("WATCH_NAMESPACE")
+	
 	// Create the handlers.
 	rfHandler := NewRedisFailoverHandler(cfg, rfService, rfChecker, rfHealer, k8sService, kooperMetricsRecorder, logger)
 	rfRetriever := NewRedisFailoverRetriever(k8sService, opNamespace)

--- a/operator/redisfailover/factory.go
+++ b/operator/redisfailover/factory.go
@@ -36,7 +36,7 @@ func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lo
 
 	// Create the handlers.
 	rfHandler := NewRedisFailoverHandler(cfg, rfService, rfChecker, rfHealer, k8sService, kooperMetricsRecorder, logger)
-	rfRetriever := NewRedisFailoverRetriever(k8sService)
+	rfRetriever := NewRedisFailoverRetriever(k8sService, lockNamespace)
 
 	kooperLogger := kooperlogger{Logger: logger.WithField("operator", "redisfailover")}
 	// Leader election service.
@@ -58,13 +58,13 @@ func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lo
 	})
 }
 
-func NewRedisFailoverRetriever(cli k8s.Services) controller.Retriever {
+func NewRedisFailoverRetriever(cli k8s.Services, lockNamespace string) controller.Retriever {
 	return controller.MustRetrieverFromListerWatcher(&cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return cli.ListRedisFailovers(context.Background(), "", options)
+			return cli.ListRedisFailovers(context.Background(), lockNamespace, options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return cli.WatchRedisFailovers(context.Background(), "", options)
+			return cli.WatchRedisFailovers(context.Background(), lockNamespace, options)
 		},
 	})
 }

--- a/operator/redisfailover/factory.go
+++ b/operator/redisfailover/factory.go
@@ -34,7 +34,7 @@ func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lo
 	rfService := rfservice.NewRedisFailoverKubeClient(k8sService, logger, kooperMetricsRecorder)
 	rfChecker := rfservice.NewRedisFailoverChecker(k8sService, redisClient, logger, kooperMetricsRecorder)
 	rfHealer := rfservice.NewRedisFailoverHealer(k8sService, redisClient, logger)
-	opNamespace := os.Getenv("WATCH_NAMESPACE")
+	watchNamespace := os.Getenv("WATCH_NAMESPACE")
 	
 	// Create the handlers.
 	rfHandler := NewRedisFailoverHandler(cfg, rfService, rfChecker, rfHealer, k8sService, kooperMetricsRecorder, logger)

--- a/operator/redisfailover/factory.go
+++ b/operator/redisfailover/factory.go
@@ -38,7 +38,7 @@ func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lo
 	
 	// Create the handlers.
 	rfHandler := NewRedisFailoverHandler(cfg, rfService, rfChecker, rfHealer, k8sService, kooperMetricsRecorder, logger)
-	rfRetriever := NewRedisFailoverRetriever(k8sService, opNamespace)
+	rfRetriever := NewRedisFailoverRetriever(k8sService, watchNamespace)
 
 	kooperLogger := kooperlogger{Logger: logger.WithField("operator", "redisfailover")}
 	// Leader election service.
@@ -60,13 +60,13 @@ func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lo
 	})
 }
 
-func NewRedisFailoverRetriever(cli k8s.Services, lockNamespace string) controller.Retriever {
+func NewRedisFailoverRetriever(cli k8s.Services, watchNamespace string) controller.Retriever {
 	return controller.MustRetrieverFromListerWatcher(&cache.ListWatch{
 		ListFunc: func(options metav1.ListOptions) (runtime.Object, error) {
-			return cli.ListRedisFailovers(context.Background(), lockNamespace, options)
+			return cli.ListRedisFailovers(context.Background(), watchNamespace, options)
 		},
 		WatchFunc: func(options metav1.ListOptions) (watch.Interface, error) {
-			return cli.WatchRedisFailovers(context.Background(), lockNamespace, options)
+			return cli.WatchRedisFailovers(context.Background(), watchNamespace, options)
 		},
 	})
 }


### PR DESCRIPTION
Fixes # .
This PR makes a redis-operator not cluster wide but namespace scoped
