### PR TITLE
Deploy and Manage Optional NetworkPolicy

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -22,15 +22,15 @@ type RedisFailover struct {
 
 // RedisFailoverSpec represents a Redis failover spec
 type RedisFailoverSpec struct {
-	Redis          RedisSettings      `json:"redis,omitempty"`
-	Sentinel       SentinelSettings   `json:"sentinel,omitempty"`
-	Auth           AuthSettings       `json:"auth,omitempty"`
-	LabelWhitelist []string           `json:"labelWhitelist,omitempty"`
+	Redis               RedisSettings      `json:"redis,omitempty"`
+	Sentinel            SentinelSettings   `json:"sentinel,omitempty"`
+	Auth                AuthSettings       `json:"auth,omitempty"`
+	LabelWhitelist      []string           `json:"labelWhitelist,omitempty"`
 	BootstrapNode       *BootstrapSettings `json:"bootstrapNode,omitempty"`
-    NetworkPolicyNsList []struct{
-    	MatchLabelKey   string `json:"matchLabelKey,omitempty"`
-    	MatchLabelValue string `json:"matchLabelValue,omitempty"`
-    }           `json:"networkPolicyNsList,omitempty"`
+	NetworkPolicyNsList []struct {
+		MatchLabelKey   string `json:"matchLabelKey,omitempty"`
+		MatchLabelValue string `json:"matchLabelValue,omitempty"`
+	} `json:"networkPolicyNsList,omitempty"`
 }
 
 // RedisCommandRename defines the specification of a "rename-command" configuration option

--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -26,7 +26,11 @@ type RedisFailoverSpec struct {
 	Sentinel       SentinelSettings   `json:"sentinel,omitempty"`
 	Auth           AuthSettings       `json:"auth,omitempty"`
 	LabelWhitelist []string           `json:"labelWhitelist,omitempty"`
-	BootstrapNode  *BootstrapSettings `json:"bootstrapNode,omitempty"`
+	BootstrapNode       *BootstrapSettings `json:"bootstrapNode,omitempty"`
+    NetworkPolicyNsList []struct{
+    	MatchLabelKey   string `json:"matchLabelKey,omitempty"`
+    	MatchLabelValue string `json:"matchLabelValue,omitempty"`
+    }           `json:"networkPolicyNsList,omitempty"`
 }
 
 // RedisCommandRename defines the specification of a "rename-command" configuration option

--- a/api/redisfailover/v1/zz_generated.deepcopy.go
+++ b/api/redisfailover/v1/zz_generated.deepcopy.go
@@ -222,6 +222,9 @@ func (in *RedisFailoverSpec) DeepCopyInto(out *RedisFailoverSpec) {
 		*out = new(BootstrapSettings)
 		**out = **in
 	}
+
+	out.NetworkPolicyNsList = in.NetworkPolicyNsList
+	
 	return
 }
 

--- a/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
+++ b/charts/redisoperator/crds/databases.spotahome.com_redisfailovers.yaml
@@ -68,6 +68,16 @@ spec:
                   port:
                     type: string
                 type: object
+              networkPolicyNsList:
+                description: NetworkPolicy provides available namespace ingress rules
+                type: array
+                items:
+                  type: object
+                  properties:
+                    matchLabelKey:
+                      type: string
+                    matchLabelValue:
+                      type: string
               labelWhitelist:
                 items:
                   type: string

--- a/manifests/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/databases.spotahome.com_redisfailovers.yaml
@@ -68,6 +68,16 @@ spec:
                   port:
                     type: string
                 type: object
+              networkPolicyNsList:
+                description: NetworkPolicy provides available namespace ingress rules
+                type: array
+                items:
+                  type: object
+                  properties:
+                    matchLabelKey:
+                      type: string
+                    matchLabelValue:
+                      type: string
               labelWhitelist:
                 items:
                   type: string

--- a/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
+++ b/manifests/kustomize/base/databases.spotahome.com_redisfailovers.yaml
@@ -68,6 +68,16 @@ spec:
                   port:
                     type: string
                 type: object
+              networkPolicyNsList:
+                description: NetworkPolicy provides available namespace ingress rules
+                type: array
+                items:
+                  type: object
+                  properties:
+                    matchLabelKey:
+                      type: string
+                    matchLabelValue:
+                      type: string
               labelWhitelist:
                 items:
                   type: string

--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -19,8 +19,10 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels 
 		}
 	}
 
-	if err := w.rfService.EnsureNetworkPolicy(rf, labels, or); err != nil {
-		return err
+	if !(len(rf.Spec.NetworkPolicyNsList) == 0) {
+    	if err := w.rfService.EnsureNetworkPolicy(rf, labels, or); err != nil {
+			return err
+		}
 	}
 
 	sentinelsAllowed := rf.SentinelsAllowed()

--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -20,7 +20,7 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels 
 	}
 
 	if !(len(rf.Spec.NetworkPolicyNsList) == 0) {
-    	if err := w.rfService.EnsureNetworkPolicy(rf, labels, or); err != nil {
+		if err := w.rfService.EnsureNetworkPolicy(rf, labels, or); err != nil {
 			return err
 		}
 	}

--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -19,6 +19,10 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels 
 		}
 	}
 
+	if err := w.rfService.EnsureNetworkPolicy(rf, labels, or); err != nil {
+		return err
+	}
+
 	sentinelsAllowed := rf.SentinelsAllowed()
 	if sentinelsAllowed {
 		if err := w.rfService.EnsureSentinelService(rf, labels, or); err != nil {

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -25,6 +25,7 @@ const (
 	redisRoleName          = "redis"
 	appLabel               = "redis-failover"
 	hostnameTopologyKey    = "kubernetes.io/hostname"
+	networkPolicyName      = "network-policy"
 )
 
 const (

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -63,7 +63,7 @@ func generateNetworkPolicy(rf *redisfailoverv1.RedisFailover, labels map[string]
 	peers := []np.NetworkPolicyPeer{}
 
 	for _, inputPeer := range networkPolicyNsList {
-		
+
 		labelKey := inputPeer.MatchLabelKey
 		labelValue := inputPeer.MatchLabelValue
 
@@ -97,7 +97,7 @@ func generateNetworkPolicy(rf *redisfailoverv1.RedisFailover, labels map[string]
 						},
 						np.NetworkPolicyPort{
 							Port: &metricsTargetPort,
-						},					
+						},
 					},
 				},
 			},

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -56,6 +56,7 @@ func generateNetworkPolicy(rf *redisfailoverv1.RedisFailover, labels map[string]
 
 	sentinelTargetPort := intstr.FromInt(26379)
 	redisTargetPort := intstr.FromInt(6379)
+	metricsTargetPort := intstr.FromInt(9121)
 
 	return &np.NetworkPolicy{
 		ObjectMeta: metav1.ObjectMeta{
@@ -75,6 +76,11 @@ func generateNetworkPolicy(rf *redisfailoverv1.RedisFailover, labels map[string]
 							NamespaceSelector: &metav1.LabelSelector{
 								MatchLabels: map[string]string{"app.kubernetes.io/instance": namespace},
 							},
+						},
+						np.NetworkPolicyPeer{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"name": "monitoring"},
+							},
 						},					
 					},
 					Ports: []np.NetworkPolicyPort{
@@ -83,6 +89,9 @@ func generateNetworkPolicy(rf *redisfailoverv1.RedisFailover, labels map[string]
 						},
 						np.NetworkPolicyPort{
 							Port: &sentinelTargetPort,
+						},
+						np.NetworkPolicyPort{
+							Port: &metricsTargetPort,
 						},					
 					},
 				},

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -13,6 +13,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 
+	np "k8s.io/api/networking/v1"
+
 	redisfailoverv1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
 	"github.com/spotahome/redis-operator/operator/redisfailover/util"
 )
@@ -44,6 +46,50 @@ sentinel parallel-syncs mymaster 2`
 
 	graceTime = 30
 )
+
+func generateNetworkPolicy(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *np.NetworkPolicy {
+	name := GetNetworkPolicyName(rf)
+	namespace := rf.Namespace
+
+	selectorLabels := generateSelectorLabels(networkPolicyName, rf.Name)
+	labels = util.MergeLabels(labels, selectorLabels)
+
+	sentinelTargetPort := intstr.FromInt(26379)
+	redisTargetPort := intstr.FromInt(6379)
+
+	return &np.NetworkPolicy{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            name,
+			Namespace:       namespace,
+			Labels:          labels,
+			OwnerReferences: ownerRefs,
+		},
+		Spec: np.NetworkPolicySpec{
+			PodSelector: metav1.LabelSelector{
+				MatchLabels: map[string]string{"app.kubernetes.io/part-of": "redis-failover"},
+			},
+			Ingress: []np.NetworkPolicyIngressRule{
+				np.NetworkPolicyIngressRule{
+					From: []np.NetworkPolicyPeer{
+						np.NetworkPolicyPeer{
+							NamespaceSelector: &metav1.LabelSelector{
+								MatchLabels: map[string]string{"app.kubernetes.io/instance": namespace},
+							},
+						},					
+					},
+					Ports: []np.NetworkPolicyPort{
+						np.NetworkPolicyPort{
+							Port: &redisTargetPort,
+						},
+						np.NetworkPolicyPort{
+							Port: &sentinelTargetPort,
+						},					
+					},
+				},
+			},
+		},
+	}
+}
 
 func generateSentinelService(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.Service {
 	name := GetSentinelName(rf)

--- a/operator/redisfailover/service/names.go
+++ b/operator/redisfailover/service/names.go
@@ -34,6 +34,11 @@ func GetSentinelName(rf *redisfailoverv1.RedisFailover) string {
 	return generateName(sentinelName, rf.Name)
 }
 
+// GetSentinelName returns the name for sentinel resources
+func GetNetworkPolicyName(rf *redisfailoverv1.RedisFailover) string {
+	return generateName(networkPolicyName, rf.Name)
+}
+
 func generateName(typeName, metaName string) string {
 	return fmt.Sprintf("%s%s-%s", baseName, typeName, metaName)
 }

--- a/service/k8s/k8s.go
+++ b/service/k8s/k8s.go
@@ -20,6 +20,7 @@ type Services interface {
 	RBAC
 	Deployment
 	StatefulSet
+	NetworkPolicy
 }
 
 type services struct {
@@ -32,6 +33,7 @@ type services struct {
 	RBAC
 	Deployment
 	StatefulSet
+	NetworkPolicy
 }
 
 // New returns a new Kubernetes service.
@@ -46,5 +48,6 @@ func New(kubecli kubernetes.Interface, crdcli redisfailoverclientset.Interface, 
 		RBAC:                NewRBACService(kubecli, logger, metricsRecorder),
 		Deployment:          NewDeploymentService(kubecli, logger, metricsRecorder),
 		StatefulSet:         NewStatefulSetService(kubecli, logger, metricsRecorder),
+		NetworkPolicy:       NewNetworkPolicyService(kubecli, logger, metricsRecorder),
 	}
 }

--- a/service/k8s/networkpolicy.go
+++ b/service/k8s/networkpolicy.go
@@ -1,0 +1,93 @@
+package k8s
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/spotahome/redis-operator/log"
+	"github.com/spotahome/redis-operator/metrics"
+
+	np "k8s.io/api/networking/v1"
+)
+
+// NetworkPolicy the ServiceAccount service that knows how to interact with k8s to manage them
+type NetworkPolicy interface {
+	GetNetworkPolicy(namespace string, name string) (*np.NetworkPolicy, error)
+	CreateNetworkPolicy(namespace string, networkPolicy *np.NetworkPolicy) error
+	UpdateNetworkPolicy(namespace string, networkPolicy *np.NetworkPolicy) error
+	CreateOrUpdateNetworkPolicy(namespace string, networkPolicy *np.NetworkPolicy) error
+	DeleteNetworkPolicy(namespace string, name string) error
+}
+
+// NetworkPolicyService is the networkPolicy service implementation using API calls to kubernetes.
+type NetworkPolicyService struct {
+	kubeClient      kubernetes.Interface
+	logger          log.Logger
+	metricsRecorder metrics.Recorder
+}
+
+// NewNetworkPolicyService returns a new NetworkPolicy KubeService.
+func NewNetworkPolicyService(kubeClient kubernetes.Interface, logger log.Logger, metricsRecorder metrics.Recorder) *NetworkPolicyService {
+	logger = logger.With("service", "k8s.networkPolicy")
+	return &NetworkPolicyService{
+		kubeClient:      kubeClient,
+		logger:          logger,
+		metricsRecorder: metricsRecorder,
+	}
+}
+
+func (p *NetworkPolicyService) GetNetworkPolicy(namespace string, name string) (*np.NetworkPolicy, error) {
+	networkPolicy, err := p.kubeClient.NetworkingV1().NetworkPolicies(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+	recordMetrics(namespace, "NetworkPolicy", name, "GET", err, p.metricsRecorder)
+	if err != nil {
+		return nil, err
+	}
+	return networkPolicy, err
+}
+
+func (p *NetworkPolicyService) CreateNetworkPolicy(namespace string, networkPolicy *np.NetworkPolicy) error {
+	_, err := p.kubeClient.NetworkingV1().NetworkPolicies(namespace).Create(context.TODO(), networkPolicy, metav1.CreateOptions{})
+	recordMetrics(namespace, "NetworkPolicy", networkPolicy.GetName(), "CREATE", err, p.metricsRecorder)
+	if err != nil {
+		return err
+	}
+	p.logger.WithField("namespace", namespace).WithField("networkPolicy", networkPolicy.Name).Debugf("NetworkPolicy created")
+	return nil
+}
+func (p *NetworkPolicyService) UpdateNetworkPolicy(namespace string, networkPolicy *np.NetworkPolicy) error {
+	_, err := p.kubeClient.NetworkingV1().NetworkPolicies(namespace).Update(context.TODO(), networkPolicy, metav1.UpdateOptions{})
+	recordMetrics(namespace, "NetworkPolicy", networkPolicy.GetName(), "UPDATE", err, p.metricsRecorder)
+	if err != nil {
+		return err
+	}
+	p.logger.WithField("namespace", namespace).WithField("networkPolicy", networkPolicy.Name).Debugf("NetworkPolicy updated")
+	return nil
+}
+func (p *NetworkPolicyService) CreateOrUpdateNetworkPolicy(namespace string, networkPolicy *np.NetworkPolicy) error {
+	storedNetworkPolicy, err := p.GetNetworkPolicy(namespace, networkPolicy.Name)
+	if err != nil {
+		// If no resource we need to create.
+		if errors.IsNotFound(err) {
+			return p.CreateNetworkPolicy(namespace, networkPolicy)
+		}
+		log.Errorf("Error while updating service %v in %v namespace : %v", networkPolicy.GetName(), namespace, err)
+		return err
+	}
+
+	// Already exists, need to Update.
+	// Set the correct resource version to ensure we are on the latest version. This way the only valid
+	// namespace is our spec(https://github.com/kubernetes/community/blob/master/contributors/devel/api-conventions.md#concurrency-control-and-consistency),
+	// we will replace the current namespace state.
+	networkPolicy.ResourceVersion = storedNetworkPolicy.ResourceVersion
+	return p.UpdateNetworkPolicy(namespace, networkPolicy)
+}
+
+func (p *NetworkPolicyService) DeleteNetworkPolicy(namespace string, name string) error {
+	propagation := metav1.DeletePropagationForeground
+	err := p.kubeClient.NetworkingV1().NetworkPolicies(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{PropagationPolicy: &propagation})
+	recordMetrics(namespace, "NetworkPolicy", name, "DELETE", err, p.metricsRecorder)
+	return err
+}

--- a/service/k8s/networkpolicy.go
+++ b/service/k8s/networkpolicy.go
@@ -91,3 +91,4 @@ func (p *NetworkPolicyService) DeleteNetworkPolicy(namespace string, name string
 	recordMetrics(namespace, "NetworkPolicy", name, "DELETE", err, p.metricsRecorder)
 	return err
 }
+


### PR DESCRIPTION
Fixes # .
Purpose of this PR is to give a redis-operator ability to create a NetworkPolicy object

The problem we want to solve by this PR is to stop sentinel's servers join `other` sentinel servers from different namespaces.