### PR TITLE
FVR-45: Add Explicit Component Labels

### DIFF
--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -70,6 +70,12 @@ func generateRedisSlaveRoleLabel() map[string]string {
 	}
 }
 
+func generateComponentLabel(componentType string) map[string]string {
+	return map[string]string{
+		"redisfailovers.databases.spotahome.com/component": componentType,
+	}
+}
+
 // EnsureNetworkPolicy makes sure the network policy exists
 func (r *RedisFailoverKubeClient) EnsureNetworkPolicy(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
 	svc := generateNetworkPolicy(rf, labels, ownerRefs)

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -56,9 +56,7 @@ func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[str
 		"app.kubernetes.io/component": "redis",
 	})
 
-	selectorLabels := util.MergeLabels(labels, map[string]string{
-		"redisfailovers.databases.spotahome.com/component": "haproxy",
-	})
+	selectorLabels := util.MergeLabels(labels, generateComponentLabel("haproxy"))
 
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -239,9 +237,10 @@ func generateHAProxyService(rf *redisfailoverv1.RedisFailover, labels map[string
 	namespace := rf.Namespace
 	redisTargetPort := intstr.FromInt(int(rf.Spec.Redis.Port))
 	selectorLabels := map[string]string{
-		"app.kubernetes.io/component":                      "redis",
-		"redisfailovers.databases.spotahome.com/component": "haproxy",
+		"app.kubernetes.io/component": "redis",
 	}
+
+	selectorLabels = util.MergeLabels(selectorLabels, generateComponentLabel("haproxy"))
 
 	selectorLabels = util.MergeLabels(labels, selectorLabels)
 
@@ -556,6 +555,8 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 	labels = util.MergeLabels(labels, selectorLabels)
 	labels = util.MergeLabels(labels, generateRedisDefaultRoleLabel())
 
+	labels = util.MergeLabels(labels, generateComponentLabel("redis"))
+
 	volumeMounts := getRedisVolumeMounts(rf)
 	volumes := getRedisVolumes(rf)
 	terminationGracePeriodSeconds := getTerminationGracePeriodSeconds(rf)
@@ -729,6 +730,8 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 	sentinelCommand := getSentinelCommand(rf)
 	selectorLabels := generateSelectorLabels(sentinelRoleName, rf.Name)
 	labels = util.MergeLabels(labels, selectorLabels)
+
+	labels = util.MergeLabels(labels, generateComponentLabel("sentinel"))
 
 	volumeMounts := getSentinelVolumeMounts(rf)
 	volumes := getSentinelVolumes(rf, configMapName)


### PR DESCRIPTION
This PR adds component labels `redisfailovers.databases.spotahome.com/component`  for `redis`, `sentinel`, `haproxy`