### PR TITLE
Update status.observedGeneration w/ Latest Ver

### DIFF
--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -125,7 +125,7 @@ func (r *RedisFailoverHandler) Handle(_ context.Context, obj runtime.Object) err
 			}
 		}
 	} else {
-		// app was deployed, make sure ObservedGeneration equails Generation
+		// app was deployed, make sure status.observedGeneration equals metadata.generation
 		if rf.GetObjectMeta().GetGeneration() != rf.Status.ObservedGeneration {
 			rf.Status.ObservedGeneration = rf.GetObjectMeta().GetGeneration()
 			r.rfService.UpdateStatus(rf)

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -124,6 +124,12 @@ func (r *RedisFailoverHandler) Handle(_ context.Context, obj runtime.Object) err
 				return err
 			}
 		}
+	} else {
+		// app was deployed, make sure ObservedGeneration equails Generation
+		if rf.GetObjectMeta().GetGeneration() != rf.Status.ObservedGeneration {
+			rf.Status.ObservedGeneration = rf.GetObjectMeta().GetGeneration()
+			r.rfService.UpdateStatus(rf)
+		}
 	}
 
 	r.mClient.SetClusterOK(rf.Namespace, rf.Name)


### PR DESCRIPTION
This PR will fix a bug when status.ObservedGeneration  does not match with Generation of resource after deploy was made