### PR TITLE
Haproxy Optional Parameters

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -50,7 +50,6 @@ sentinel parallel-syncs mymaster 2`
 const (
 	redisHAProxyName     = "redis-haproxy"
 	redisHAProxyHostName = "redis-haproxy"
-	redisHAProxyImage    = "haproxy:2.4"
 )
 
 func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *appsv1.Deployment {
@@ -87,10 +86,6 @@ func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[str
 	}
 
 	image := rf.Spec.Haproxy.Image
-
-	if image == "" {
-		image = redisHAProxyImage
-	}
 
 	sd := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -47,10 +47,7 @@ sentinel parallel-syncs mymaster 2`
 	graceTime = 30
 )
 
-const (
-	redisHAProxyName     = "redis-haproxy"
-	redisHAProxyHostName = "redis-haproxy"
-)
+const redisHAProxyName = "redis-haproxy"
 
 func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *appsv1.Deployment {
 	name := redisHAProxyName
@@ -78,7 +75,7 @@ func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[str
 			VolumeSource: corev1.VolumeSource{
 				ConfigMap: &corev1.ConfigMapVolumeSource{
 					LocalObjectReference: corev1.LocalObjectReference{
-						Name: "redis-haproxy",
+						Name: redisHAProxyName,
 					},
 				},
 			},
@@ -133,7 +130,7 @@ func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[str
 }
 
 func generateHAProxyConfigmap(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.ConfigMap {
-	name := "redis-haproxy"
+	name := redisHAProxyName
 	namespace := rf.Namespace
 
 	labels = util.MergeLabels(labels, map[string]string{
@@ -241,7 +238,7 @@ func generateHAProxyService(rf *redisfailoverv1.RedisFailover, labels map[string
 	name := rf.Spec.Haproxy.RedisHost
 
 	if name == "" {
-		name = redisHAProxyHostName
+		name = redisHAProxyName
 	}
 
 	namespace := rf.Namespace

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -85,8 +85,6 @@ func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[str
 		},
 	}
 
-	image := rf.Spec.Haproxy.Image
-
 	sd := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
@@ -107,7 +105,7 @@ func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[str
 					Containers: []corev1.Container{
 						{
 							Name:  "haproxy",
-							Image: image,
+							Image: rf.Spec.Haproxy.Image,
 							Ports: []corev1.ContainerPort{
 								{
 									ContainerPort: 8080,


### PR DESCRIPTION
This PR make HAProxy `image` and `hostName` optional. By default `image` will be `haproxy:2.4` and `hostname` will be `redis-haproxy`