### PR TITLE
Update Status When CR Modified

### DIFF
--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -89,7 +89,13 @@ func (r *RedisFailoverHandler) Handle(_ context.Context, obj runtime.Object) err
 				Message: "RedisFailover reconciling...",
 			})
 			rf.Status.ObservedGeneration = rf.GetObjectMeta().GetGeneration()
-			r.rfService.UpdateStatus(rf)
+			_, err := r.rfService.UpdateStatus(rf)
+
+			if err != nil {
+				r.mClient.SetClusterError(rf.Namespace, rf.Name)
+				r.logger.Errorf("Error attempting to update RedisFailover Status: %s", err)
+				return err
+			}
 		}
 	}
 

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -59,6 +59,7 @@ func (r *RedisFailoverHandler) Handle(_ context.Context, obj runtime.Object) err
 		return fmt.Errorf("can't handle the received object: not a redisfailover")
 	}
 
+	// if versions are not equaled, that means resource was updated and status needs to be updated
 	if rf.GetObjectMeta().GetGeneration() != rf.Status.ObservedGeneration {
 		rf.Status.AddCondition(redisfailoverv1.ClusterCondition{
 			Status:  redisfailoverv1.ConditionTrue,
@@ -67,8 +68,6 @@ func (r *RedisFailoverHandler) Handle(_ context.Context, obj runtime.Object) err
 		})
 		r.rfService.UpdateStatus(rf)
 	}
-
-	r.logger.Infof("generation is: %d, %d", rf.GetObjectMeta().GetGeneration(), rf.Status.ObservedGeneration)
 
 	// initial condition type is `Pending`
 	if len(rf.Status.Conditions) == 0 {

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -82,6 +82,7 @@ func (r *RedisFailoverHandler) Handle(_ context.Context, obj runtime.Object) err
 		// If the versions do not match, this signifies that the resource has been updated and therefore, the status also requires updating.
 		if rf.GetObjectMeta().GetGeneration() != rf.Status.ObservedGeneration {
 
+			rf.Status.Conditions = []redisfailoverv1.ClusterCondition{}
 			rf.Status.AddCondition(redisfailoverv1.ClusterCondition{
 				Status:  redisfailoverv1.ConditionTrue,
 				Type:    redisfailoverv1.AppStatePending,

--- a/operator/redisfailover/handler.go
+++ b/operator/redisfailover/handler.go
@@ -59,7 +59,7 @@ func (r *RedisFailoverHandler) Handle(_ context.Context, obj runtime.Object) err
 		return fmt.Errorf("can't handle the received object: not a redisfailover")
 	}
 
-	// if versions are not equaled, that means resource was updated and status needs to be updated
+	// If the versions do not match, this signifies that the resource has been updated and therefore, the status also requires updating.
 	if rf.GetObjectMeta().GetGeneration() != rf.Status.ObservedGeneration {
 		rf.Status.AddCondition(redisfailoverv1.ClusterCondition{
 			Status:  redisfailoverv1.ConditionTrue,


### PR DESCRIPTION
This PR addresses the Redis reconciliation error. 
When deploying a resource using Krane, it is crucial to compare the `ObservedGeneration` of the RedisFailover resource to its status `ObservedGeneration`. If there's a discrepancy, it indicates that the resource is undergoing an update. The operator must then adjust the `status` to ensure Krane waits for the resource update to complete.