### PR TITLE
Add static clusterip to redis master service

### DIFF
--- a/api/redisfailover/v1/types.go
+++ b/api/redisfailover/v1/types.go
@@ -123,6 +123,7 @@ type RedisSettings struct {
 	CustomReadinessProbe          *corev1.Probe                     `json:"customReadinessProbe,omitempty"`
 	CustomStartupProbe            *corev1.Probe                     `json:"customStartupProbe,omitempty"`
 	DisablePodDisruptionBudget    bool                              `json:"disablePodDisruptionBudget,omitempty"`
+	Service                       *ServiceSettings                  `json:"service,omitempty"`
 }
 
 // SentinelSettings defines the specification of the sentinel cluster

--- a/api/redisfailover/v1/zz_generated.deepcopy.go
+++ b/api/redisfailover/v1/zz_generated.deepcopy.go
@@ -432,6 +432,11 @@ func (in *RedisSettings) DeepCopyInto(out *RedisSettings) {
 		*out = new(corev1.Probe)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Service != nil {
+		in, out := &in.Service, &out.Service
+		*out = new(ServiceSettings)
+		**out = **in
+	}
 	return
 }
 

--- a/client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go
+++ b/client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go
@@ -87,14 +87,14 @@ func (c *FakeRedisFailovers) Update(ctx context.Context, redisFailover *v1.Redis
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeRedisFailovers) UpdateStatus(ctx context.Context, redisFailover *redisfailoverv1.RedisFailover, opts v1.UpdateOptions) (*redisfailoverv1.RedisFailover, error) {
+func (c *FakeRedisFailovers) UpdateStatus(ctx context.Context, redisFailover *v1.RedisFailover, opts metav1.UpdateOptions) (*v1.RedisFailover, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(redisfailoversResource, "status", c.ns, redisFailover), &redisfailoverv1.RedisFailover{})
+		Invokes(testing.NewUpdateSubresourceAction(redisfailoversResource, "status", c.ns, redisFailover), &v1.RedisFailover{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*redisfailoverv1.RedisFailover), err
+	return obj.(*v1.RedisFailover), err
 }
 
 // Delete takes name of the redisFailover and deletes it. Returns an error if one occurs.


### PR DESCRIPTION
# Summary

Depends on: https://github.com/powerhome/pac/pull/1726

Adds the ability to (optionally) add a static ClusterIP to the RedisFailover's "Master" service.

## Context

This change allows the RedisFailover to be configured with a Static ClusterIP. The redis-operator documentation subtly mentions that the `bootstrapNode` should be pointed at the ClusterIP of the Redis Cluster's Master node. The redis-operator recently added a Service object expose the Master node via a ClusterIP. 

When testing cross-site, async replication using the `bootstrapNode` - to create a warm standby - we attempted to use the primary site's HAProxy Service's ClusterIP to setup replication on the secondary site. This caused the primary site's Redis Cluster to fall apart. An example recreating this behavior in a local kind cluster:

1. The secondary site's replica nodes cannot connect to the primary site's master node
```
1:S 18 Sep 2023 21:51:39.812 * Connecting to MASTER [haproxy-service-ip]:6379
1:S 18 Sep 2023 21:51:39.812 * MASTER <-> REPLICA sync started
1:S 18 Sep 2023 21:51:39.812 * Non blocking connect for SYNC fired the event.
1:S 18 Sep 2023 21:51:39.812 * Master replied to PING, replication can continue...
1:S 18 Sep 2023 21:51:39.812 * Trying a partial resynchronization (request f89b815577d0ac07377259548ed5bbb5eb14a0f9:40904).
1:S 18 Sep 2023 21:51:39.813 * Master is currently unable to PSYNC but should be in the future: -NOMASTERLINK Can't SYNC while not connected with my master
```
3. The primary site's master node's replication configuration cycles between being set as a salve of itself, a master with an incomplete list of primary site slaves, and a master with the list of HAProxy pods as its slaves. On the primary master node:

Master as slave of self:
```
$ kubectl --context kind-test --namespace redis-operator-test exec -it rfr-primary-1 -- redis-cli info replication
# Replication
role:slave
master_host:[self-pod-ip]
master_port:6379
master_link_status:down
...
```

Master with partial list of slaves
```
$ kubectl --context kind-test --namespace redis-operator-test exec -it rfr-primary-1 -- redis-cli info replication
# Replication
role:master
connected_slaves:1
slave0:ip=10.244.0.59,port=6379,state=online,offset=0,lag=0
master_failover_state:no-failover
```

Master as a slave of HAPRoxy Pod
```
$ kubectl --context kind-test --namespace redis-operator-test exec -it rfr-primary-1 -- redis-cli info replication
# Replication
role:slave
master_host:10.244.0.43
master_port:6379
master_link_status:down
```
4. The primary site's slaves are reconfigured to replicate from an HAProxy Pod's IP address
```
/data $ redis-cli info replication
# Replication
role:slave
master_host:[haproxy-pod-ip]
```
5. The Sentinels get stuck trying to reconfigure the primary site's master node as a slave 
```
sentinel 1:X 18 Sep 2023 21:14:10.294 * +slave slave [redis-master-pod-ip]:6379 [redis-master-pod-ip] 6379 @ mymaster [haproxy-pod-ip] 6379
```
6. The redis-operator detects that something serious is going on and gives up on auto-healing, indicating that manual resolution is required.
```
time="2023-09-18T21:11:47Z" level=warning msg="Number of Masters running is 0" namespace=redis-operator-test redisfailover=primary src="handler.go:118"
time="2023-09-18T21:11:47Z" level=info msg="No master avaiable but max pod up time is : 1844.000000" namespace=redis-operator-test redisfailover=primary src="handler.go:118"
time="2023-09-18T21:11:47Z" level=info msg="atleast one pod does not have localhost as master , operator should not heal" src="checker.go:157"
time="2023-09-18T21:11:47Z" level=info msg="no master found, wait until failover or fix manually" namespace=redis-operator-test redisfailover=primary src="handler.go:118"
```

## Testing / 🎩 

I'm using a "development" image of the redis-operator: `image-registry.powerapp.cloud/redis-operator/spotahome:80a70ed8fb40a7311a7abdb3e1c55b0e93fefdb7` with the CRD defined in https://github.com/powerhome/pac/pull/1726

1. Assign a static ClusterIP to the primary site's Redis Master node's service:

```yaml
apiVersion: databases.spotahome.com/v1
kind: RedisFailover
metadata:
  name: primary
  namespace: redis-operator-test
spec:
  haproxy:
    service:
      clusterIP: 10.96.200.200
    image: haproxy:2.4
    redisHost: redis
    replicas: 2
    resources:
      limits:
        ephemeral-storage: 500Mi
        memory: 500Mi
      requests:
        cpu: 100m
        ephemeral-storage: 500Mi
        memory: 500Mi
  redis:
    service:
      clusterIP: 10.96.201.201
    customConfig:
    - save ""
    - appendonly yes
    replicas: 3
    resources:
      limits:
        cpu: 400m
        memory: 500Mi
      requests:
        cpu: 100m
        memory: 100Mi
  sentinel:
    replicas: 3
    resources:
      limits:
        memory: 100Mi
      requests:
        cpu: 100m
```

```
$ kubectl --context kind-test --namespace redis-operator-test get svc
NAME              TYPE        CLUSTER-IP      EXTERNAL-IP   PORT(S)     AGE
primary-haproxy   ClusterIP   10.96.200.200   <none>        6379/TCP    8s
...
rfrm-primary      ClusterIP   10.96.201.201   <none>        6379/TCP    64m
...
...
```

2. Configuring the replica cluster using `10.96.200.200` as the `bootstrapNode` host (`primary-haproxy`) causes the primary Redis cluster to disassemble as described above. 
```yaml
---
apiVersion: databases.spotahome.com/v1
kind: RedisFailover
metadata:
  name: replica
  namespace: redis-operator-test
spec:
  bootstrapNode:
    host: 10.96.200.200
    allowSentinels: false
  redis:
    customConfig:
    - save ""
    - appendonly yes
    replicas: 3
    resources:
      limits:
        cpu: 400m
        memory: 500Mi
      requests:
        cpu: 100m
        memory: 100Mi
  sentinel:
    replicas: 3
    resources:
      limits:
        memory: 100Mi
      requests:
        cpu: 100m
```
3. Reconfigure the replica cluster using `10.96.201.201` as the `bootstrapNode` host (`rfrm-primary`). Then delete the primary site's redis pods. Watch the Sentinels become healthy, the redis-operator sets a master, and the secondary replica pods being syncing data from the primary reids cluster. 
```yaml
---
apiVersion: databases.spotahome.com/v1
kind: RedisFailover
metadata:
  name: replica
  namespace: redis-operator-test
spec:
  bootstrapNode:
    host: 10.96.201.201
    allowSentinels: false
  redis:
    customConfig:
    - save ""
    - appendonly yes
    replicas: 3
    resources:
      limits:
        cpu: 400m
        memory: 500Mi
      requests:
        cpu: 100m
        memory: 100Mi
  sentinel:
    replicas: 3
    resources:
      limits:
        memory: 100Mi
      requests:
        cpu: 100m
```