### PR TITLE
Fix status when bootstrapping

### DIFF
--- a/operator/redisfailover/service/check.go
+++ b/operator/redisfailover/service/check.go
@@ -505,6 +505,9 @@ func (r *RedisFailoverChecker) IsHAProxyRunning(rFailover *redisfailoverv1.Redis
 
 // IsClusterRunning returns true if all the pods in the given redisfailover are Running
 func (r *RedisFailoverChecker) IsClusterRunning(rFailover *redisfailoverv1.RedisFailover) bool {
+	if rFailover.Bootstrapping() && !rFailover.SentinelsAllowed() {
+		return r.IsRedisRunning(rFailover) && r.IsHAProxyRunning(rFailover)
+	}
 	return r.IsSentinelRunning(rFailover) && r.IsRedisRunning(rFailover) && r.IsHAProxyRunning(rFailover)
 }
 


### PR DESCRIPTION
# Summary

Fix custom status conditions / transitions when the cluster is set to bootstrap.

# Context

When the RedisFailover is set to bootstrap its data from another Redis instance, the status / condition never transitions away form "Initializing RedisFailover..." even if the Redis cluster comes up. 

The operator asks the checker if the all of the resources for the RedisFailover are in a running status - `IsClusterRunning`. However, the logic of `IsClusterRunning` doesn't consider that when the RedisFailover is boottrapping, the operator purposefully does NOT create the Sentinel resource. 

The `IsClusterRunning` method is only ever used during this check in the status updating `handler` logic we added:

https://github.com/powerhome/redis-operator/blob/d9cd24fcfad5d6013a69f25877fe8bba4b01f43b/operator/redisfailover/handler.go#L124-L146

With this change, the checker logic now knows if the sentinels' "Running" status should be considered based if the sentinels are expected to be deployed or not. This allows the RedisFailover resource to transition to the "RedisFailover initialized successfully"

# Testing / 🎩 

Using a development redis-operator image `image-registry.powerapp.cloud/redis-operator/spotahome:1354d58f1f058a72f7755615d3744a1fe6db81f3`, I created this bootstrapping RedisFailover resource and watched its State transition to "RedisFailover initialized successfully" once all of the Redis and HAProxy pods were started:

```yaml
---
apiVersion: databases.spotahome.com/v1
kind: RedisFailover
metadata:
  name: redis-bootstrap
  namespace: redis-operator-test
spec:
  bootstrapNode:
    host: data-source-redis-master
  haproxy:
    redisHost: replica-haproxy
    image: haproxy:2.4
    replicas: 2
    resources:
      limits:
        ephemeral-storage: 500Mi
        memory: 500Mi
      requests:
        cpu: 100m
        ephemeral-storage: 500Mi
        memory: 500Mi
  redis:
    replicas: 3
    resources:
      limits:
        cpu: 400m
        memory: 500Mi
      requests:
        cpu: 100m
        memory: 100Mi
  sentinel:
    replicas: 3
    resources:
      limits:
        memory: 100Mi
      requests:
        cpu: 100m

```