### PR TITLE
Fix unit tests

### DIFF
--- a/client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go
+++ b/client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go
@@ -87,14 +87,14 @@ func (c *FakeRedisFailovers) Update(ctx context.Context, redisFailover *v1.Redis
 
 // UpdateStatus was generated because the type contains a Status member.
 // Add a +genclient:noStatus comment above the type to avoid generating UpdateStatus().
-func (c *FakeRedisFailovers) UpdateStatus(ctx context.Context, redisFailover *redisfailoverv1.RedisFailover, opts v1.UpdateOptions) (*redisfailoverv1.RedisFailover, error) {
+func (c *FakeRedisFailovers) UpdateStatus(ctx context.Context, redisFailover *v1.RedisFailover, opts metav1.UpdateOptions) (*v1.RedisFailover, error) {
 	obj, err := c.Fake.
-		Invokes(testing.NewUpdateSubresourceAction(redisfailoversResource, "status", c.ns, redisFailover), &redisfailoverv1.RedisFailover{})
+		Invokes(testing.NewUpdateSubresourceAction(redisfailoversResource, "status", c.ns, redisFailover), &v1.RedisFailover{})
 
 	if obj == nil {
 		return nil, err
 	}
-	return obj.(*redisfailoverv1.RedisFailover), err
+	return obj.(*v1.RedisFailover), err
 }
 
 // Delete takes name of the redisFailover and deletes it. Returns an error if one occurs.

--- a/docker/development/Dockerfile
+++ b/docker/development/Dockerfile
@@ -17,8 +17,11 @@ RUN wget http://github.com/kubernetes/code-generator/archive/kubernetes-${CODEGE
     touch /go/src/k8s.io/kubernetes/hack/boilerplate/boilerplate.go.txt
 
 # Mock creator
+# Alpine labels ARM architectures differently than Mockery: https://wiki.alpinelinux.org/wiki/Architecture
 ARG MOCKERY_VERSION="2.32.0"
-RUN wget -c https://github.com/vektra/mockery/releases/download/v${MOCKERY_VERSION}/mockery_${MOCKERY_VERSION}_$(uname -o)_$(uname -m).tar.gz -O - | tar -xz -C /go/bin/
+RUN export ARCH="$(uname -m)" \
+    && if [[ "${ARCH}" == "aarch64" ]]; then export ARCH="arm64"; fi \
+    && wget -c https://github.com/vektra/mockery/releases/download/v${MOCKERY_VERSION}/mockery_${MOCKERY_VERSION}_$(uname -o)_${ARCH}.tar.gz -O - | tar -xz -C /go/bin/
 
 # Create user
 ARG uid=1000


### PR DESCRIPTION
# Sumamry

Closes: https://nitro.powerhrg.com/runway/backlog_items/FVR-118

Fix the `make unit-test` target

# Context

First, fix the redisfailvoer module name in the Fake RedisFailover. This is causing the unit tests to fail because the RedisFailvoer module is imported a `v1`, not `redisfailoverv1`. 

Second, fixes the development image build on Apple Silicon. The development image Dockerfile fetches the `mockery` library using the container OS' architecture - `$(uname -m)`. [Alpine](https://wiki.alpinelinux.org/wiki/Architecture) and [Mockery](https://github.com/vektra/mockery/releases/tag/v2.32.0) use different names for ARM architectures; `aarch64` and `amd64` respectively. 

# 🎩 

If anyone has an intel-based development machine I'd be grateful for a quick validation that `make unit-test` still builds the dev image on that architecture. I don't have any reason to believe that this change would break other architectures, but I've been bit by assumptions like this in the past. 

**Before:**

```
$ make unit-test
...
 > [4/6] RUN wget -c https://github.com/vektra/mockery/releases/download/v2.32.0/mockery_2.32.0_$(uname -o)_$(uname -m).tar.gz -O - | tar -xz -C /go/bin/:
0.129 Connecting to github.com (140.82.113.4:443)
0.257 wget: server returned error: HTTP/1.1 404 Not Found
0.257 tar: invalid magic
0.257 tar: short read
------
Dockerfile:21
--------------------
  19 |     # Mock creator
  20 |     ARG MOCKERY_VERSION="2.32.0"
  21 | >>> RUN wget -c https://github.com/vektra/mockery/releases/download/v${MOCKERY_VERSION}/mockery_${MOCKERY_VERSION}_$(uname -o)_$(uname -m).tar.gz -O - | tar -xz -C /go/bin/
  22 |
  23 |     # Create user
--------------------
ERROR: failed to solve: process "/bin/sh -c wget -c https://github.com/vektra/mockery/releases/download/v${MOCKERY_VERSION}/mockery_${MOCKERY_VERSION}_$(uname -o)_$(uname -m).tar.gz -O - | tar -xz -C /go/bin/" did not complete successfully: exit code: 1
make: *** [docker-build] Error 1
```

...and

```
$ make unit-test
...
client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go:90:79: undefined: redisfailoverv1
client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go:90:118: undefined: v1.UpdateOptions
client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go:90:135: undefined: redisfailoverv1
client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go:92:103: undefined: redisfailoverv1
client/k8s/clientset/versioned/typed/redisfailover/v1/fake/fake_redisfailover.go:97:15: undefined: redisfailoverv1
...
PASS
ok  	github.com/spotahome/redis-operator/service/k8s	0.012s
FAIL
make: *** [unit-test] Error 1
```

**After:**

```
make unit-test && [[ $? -eq 0 ]] && echo "All test passed" || echo "At least one test failed"
...
PASS
ok  	github.com/spotahome/redis-operator/service/k8s	0.017s
```