### PR TITLE
[FVR-76] Fix kube 1.21 DisruptionBudget deprecation warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 Check [releases](https://github.com/spotahome/redis-operator/releases) section for Changelog
 
+## Unreleased
+
+- [Fix PodDisruptionBudget deprecation warnings on kube 1.21+](https://github.com/powerhome/redis-operator/pull/19)
+
 ## [v1.1.0-rc.3] - 2022-01-19
 ### Changes
 - Fixed support for kubernetes <1.21
@@ -10,7 +14,7 @@ Check [releases](https://github.com/spotahome/redis-operator/releases) section f
 ### Changes
 - Allow configuration of exporter resource
 - Fix persistent volume claim metadata management
-- Add arm64,arm,amd64 docker images 
+- Add arm64,arm,amd64 docker images
 
 Update notes:
 
@@ -53,7 +57,7 @@ For detailed changelogs see rc relases
 ## [v1.0.0-rc.5] - 2020-02-07
 
 ### Changes
-- Custom annotations for services #216 @alecjacobs5401 
+- Custom annotations for services #216 @alecjacobs5401
 - Update redis-exporter #222 @VerosK
 - Pod security policy to run as non root #228 @logdnalf
 - Custom command renames #234 @logdnalf
@@ -62,7 +66,7 @@ For detailed changelogs see rc relases
 - Add fsGroup to security context #215 @ese
 - Pod disruption budget lower than replicas #229 @tkrop
 - Add password support for readiness probes #235 @teamon
-  
+
 ## [v1.0.0-rc.4] - 2019-12-17
 
 ### Changes
@@ -75,7 +79,7 @@ For detailed changelogs see rc relases
 ### Action required
 
 Since update logic has been moved to operator, `PodManagementPolicy` has been set to `Parallel` in redis statefulSet. This improve bootstrap times.
-This field is immutable so to upgrade from previous rc releases you need to delete statefulSets manually. 
+This field is immutable so to upgrade from previous rc releases you need to delete statefulSets manually.
 *Note:* you can use `--cascade=false` flag to avoid disruption, pods will be adopted by the new statefulSet created by the operator.
 example: `kubectl delete statefulset --cascade=false rfr-redisfailover`
 
@@ -97,14 +101,14 @@ example: `kubectl delete statefulset --cascade=false rfr-redisfailover`
 
 - Add custom annotations for pods in the CRD `podAnnotations` @alecjacobs5401
 - Add redis authentication @hoffoo
-- Configurable imagePullSecret @romanfurst 
-- Configurable imagePullPolicy @mcdiae 
-- Support for node selector `nodeSelector` @sergeunity 
+- Configurable imagePullSecret @romanfurst
+- Configurable imagePullPolicy @mcdiae
+- Support for node selector `nodeSelector` @sergeunity
 
 ### Fix
 
 - Add RBAC policy for the CRD finalizer @mcanevet
-- Examples documentation  @SataQiu @marcemq 
+- Examples documentation  @SataQiu @marcemq
 - Chart service labels @timmyers
 - Memory requests and limits for sentinel @marcemq
 - Execution permissions in shutdown script @glebpom

--- a/mocks/service/k8s/Services.go
+++ b/mocks/service/k8s/Services.go
@@ -12,14 +12,13 @@ import (
 	mock "github.com/stretchr/testify/mock"
 
 	networkingv1 "k8s.io/api/networking/v1"
+	policyv1 "k8s.io/api/policy/v1"
 
 	rbacv1 "k8s.io/api/rbac/v1"
 
 	redisfailoverv1 "github.com/spotahome/redis-operator/api/redisfailover/v1"
 
 	v1 "k8s.io/api/core/v1"
-
-	v1beta1 "k8s.io/api/policy/v1beta1"
 
 	watch "k8s.io/apimachinery/pkg/watch"
 )
@@ -142,11 +141,11 @@ func (_m *Services) CreateOrUpdatePod(namespace string, pod *v1.Pod) error {
 }
 
 // CreateOrUpdatePodDisruptionBudget provides a mock function with given fields: namespace, podDisruptionBudget
-func (_m *Services) CreateOrUpdatePodDisruptionBudget(namespace string, podDisruptionBudget *v1beta1.PodDisruptionBudget) error {
+func (_m *Services) CreateOrUpdatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
 	ret := _m.Called(namespace, podDisruptionBudget)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *v1beta1.PodDisruptionBudget) error); ok {
+	if rf, ok := ret.Get(0).(func(string, *policyv1.PodDisruptionBudget) error); ok {
 		r0 = rf(namespace, podDisruptionBudget)
 	} else {
 		r0 = ret.Error(0)
@@ -226,11 +225,11 @@ func (_m *Services) CreatePod(namespace string, pod *v1.Pod) error {
 }
 
 // CreatePodDisruptionBudget provides a mock function with given fields: namespace, podDisruptionBudget
-func (_m *Services) CreatePodDisruptionBudget(namespace string, podDisruptionBudget *v1beta1.PodDisruptionBudget) error {
+func (_m *Services) CreatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
 	ret := _m.Called(namespace, podDisruptionBudget)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *v1beta1.PodDisruptionBudget) error); ok {
+	if rf, ok := ret.Get(0).(func(string, *policyv1.PodDisruptionBudget) error); ok {
 		r0 = rf(namespace, podDisruptionBudget)
 	} else {
 		r0 = ret.Error(0)
@@ -550,19 +549,15 @@ func (_m *Services) GetPod(namespace string, name string) (*v1.Pod, error) {
 }
 
 // GetPodDisruptionBudget provides a mock function with given fields: namespace, name
-func (_m *Services) GetPodDisruptionBudget(namespace string, name string) (*v1beta1.PodDisruptionBudget, error) {
+func (_m *Services) GetPodDisruptionBudget(namespace string, name string) (*policyv1.PodDisruptionBudget, error) {
 	ret := _m.Called(namespace, name)
 
-	var r0 *v1beta1.PodDisruptionBudget
-	var r1 error
-	if rf, ok := ret.Get(0).(func(string, string) (*v1beta1.PodDisruptionBudget, error)); ok {
-		return rf(namespace, name)
-	}
-	if rf, ok := ret.Get(0).(func(string, string) *v1beta1.PodDisruptionBudget); ok {
+	var r0 *policyv1.PodDisruptionBudget
+	if rf, ok := ret.Get(0).(func(string, string) *policyv1.PodDisruptionBudget); ok {
 		r0 = rf(namespace, name)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*v1beta1.PodDisruptionBudget)
+			r0 = ret.Get(0).(*policyv1.PodDisruptionBudget)
 		}
 	}
 
@@ -944,11 +939,11 @@ func (_m *Services) UpdatePod(namespace string, pod *v1.Pod) error {
 }
 
 // UpdatePodDisruptionBudget provides a mock function with given fields: namespace, podDisruptionBudget
-func (_m *Services) UpdatePodDisruptionBudget(namespace string, podDisruptionBudget *v1beta1.PodDisruptionBudget) error {
+func (_m *Services) UpdatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
 	ret := _m.Called(namespace, podDisruptionBudget)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, *v1beta1.PodDisruptionBudget) error); ok {
+	if rf, ok := ret.Get(0).(func(string, *policyv1.PodDisruptionBudget) error); ok {
 		r0 = rf(namespace, podDisruptionBudget)
 	} else {
 		r0 = ret.Error(0)

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -9,7 +9,7 @@ import (
 
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -970,15 +970,15 @@ func generateSentinelDeployment(rf *redisfailoverv1.RedisFailover, labels map[st
 	return sd
 }
 
-func generatePodDisruptionBudget(name string, namespace string, labels map[string]string, ownerRefs []metav1.OwnerReference, minAvailable intstr.IntOrString) *policyv1beta1.PodDisruptionBudget {
-	return &policyv1beta1.PodDisruptionBudget{
+func generatePodDisruptionBudget(name string, namespace string, labels map[string]string, ownerRefs []metav1.OwnerReference, minAvailable intstr.IntOrString) *policyv1.PodDisruptionBudget {
+	return &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            name,
 			Namespace:       namespace,
 			Labels:          labels,
 			OwnerReferences: ownerRefs,
 		},
-		Spec: policyv1beta1.PodDisruptionBudgetSpec{
+		Spec: policyv1.PodDisruptionBudgetSpec{
 			MinAvailable: &minAvailable,
 			Selector: &metav1.LabelSelector{
 				MatchLabels: labels,

--- a/service/k8s/poddisruptionbudget.go
+++ b/service/k8s/poddisruptionbudget.go
@@ -3,7 +3,7 @@ package k8s
 import (
 	"context"
 
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -14,10 +14,10 @@ import (
 
 // PodDisruptionBudget the ServiceAccount service that knows how to interact with k8s to manage them
 type PodDisruptionBudget interface {
-	GetPodDisruptionBudget(namespace string, name string) (*policyv1beta1.PodDisruptionBudget, error)
-	CreatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1beta1.PodDisruptionBudget) error
-	UpdatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1beta1.PodDisruptionBudget) error
-	CreateOrUpdatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1beta1.PodDisruptionBudget) error
+	GetPodDisruptionBudget(namespace string, name string) (*policyv1.PodDisruptionBudget, error)
+	CreatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1.PodDisruptionBudget) error
+	UpdatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1.PodDisruptionBudget) error
+	CreateOrUpdatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1.PodDisruptionBudget) error
 	DeletePodDisruptionBudget(namespace string, name string) error
 }
 
@@ -38,8 +38,8 @@ func NewPodDisruptionBudgetService(kubeClient kubernetes.Interface, logger log.L
 	}
 }
 
-func (p *PodDisruptionBudgetService) GetPodDisruptionBudget(namespace string, name string) (*policyv1beta1.PodDisruptionBudget, error) {
-	podDisruptionBudget, err := p.kubeClient.PolicyV1beta1().PodDisruptionBudgets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+func (p *PodDisruptionBudgetService) GetPodDisruptionBudget(namespace string, name string) (*policyv1.PodDisruptionBudget, error) {
+	podDisruptionBudget, err := p.kubeClient.PolicyV1().PodDisruptionBudgets(namespace).Get(context.TODO(), name, metav1.GetOptions{})
 	recordMetrics(namespace, "PodDisruptionBudget", name, "GET", err, p.metricsRecorder)
 	if err != nil {
 		return nil, err
@@ -47,8 +47,8 @@ func (p *PodDisruptionBudgetService) GetPodDisruptionBudget(namespace string, na
 	return podDisruptionBudget, nil
 }
 
-func (p *PodDisruptionBudgetService) CreatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1beta1.PodDisruptionBudget) error {
-	_, err := p.kubeClient.PolicyV1beta1().PodDisruptionBudgets(namespace).Create(context.TODO(), podDisruptionBudget, metav1.CreateOptions{})
+func (p *PodDisruptionBudgetService) CreatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
+	_, err := p.kubeClient.PolicyV1().PodDisruptionBudgets(namespace).Create(context.TODO(), podDisruptionBudget, metav1.CreateOptions{})
 	recordMetrics(namespace, "PodDisruptionBudget", podDisruptionBudget.GetName(), "CREATE", err, p.metricsRecorder)
 	if err != nil {
 		return err
@@ -57,8 +57,8 @@ func (p *PodDisruptionBudgetService) CreatePodDisruptionBudget(namespace string,
 	return nil
 }
 
-func (p *PodDisruptionBudgetService) UpdatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1beta1.PodDisruptionBudget) error {
-	_, err := p.kubeClient.PolicyV1beta1().PodDisruptionBudgets(namespace).Update(context.TODO(), podDisruptionBudget, metav1.UpdateOptions{})
+func (p *PodDisruptionBudgetService) UpdatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
+	_, err := p.kubeClient.PolicyV1().PodDisruptionBudgets(namespace).Update(context.TODO(), podDisruptionBudget, metav1.UpdateOptions{})
 	recordMetrics(namespace, "PodDisruptionBudget", podDisruptionBudget.GetName(), "UPDATE", err, p.metricsRecorder)
 	if err != nil {
 		return err
@@ -67,7 +67,7 @@ func (p *PodDisruptionBudgetService) UpdatePodDisruptionBudget(namespace string,
 	return nil
 }
 
-func (p *PodDisruptionBudgetService) CreateOrUpdatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1beta1.PodDisruptionBudget) error {
+func (p *PodDisruptionBudgetService) CreateOrUpdatePodDisruptionBudget(namespace string, podDisruptionBudget *policyv1.PodDisruptionBudget) error {
 	storedPodDisruptionBudget, err := p.GetPodDisruptionBudget(namespace, podDisruptionBudget.Name)
 	if err != nil {
 		// If no resource we need to create.
@@ -86,7 +86,7 @@ func (p *PodDisruptionBudgetService) CreateOrUpdatePodDisruptionBudget(namespace
 }
 
 func (p *PodDisruptionBudgetService) DeletePodDisruptionBudget(namespace string, name string) error {
-	err := p.kubeClient.PolicyV1beta1().PodDisruptionBudgets(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
+	err := p.kubeClient.PolicyV1().PodDisruptionBudgets(namespace).Delete(context.TODO(), name, metav1.DeleteOptions{})
 	recordMetrics(namespace, "PodDisruptionBudget", name, "DELETE", err, p.metricsRecorder)
 	return err
 }

--- a/service/k8s/poddisruptionbudget_test.go
+++ b/service/k8s/poddisruptionbudget_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	policyv1beta1 "k8s.io/api/policy/v1beta1"
+	policyv1 "k8s.io/api/policy/v1"
 	kubeerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -18,11 +18,9 @@ import (
 	"github.com/spotahome/redis-operator/service/k8s"
 )
 
-var (
-	podDisruptionBudgetsGroup = schema.GroupVersionResource{Group: "policy", Version: "v1beta1", Resource: "poddisruptionbudgets"}
-)
+var podDisruptionBudgetsGroup = schema.GroupVersionResource{Group: "policy", Version: "v1", Resource: "poddisruptionbudgets"}
 
-func newPodDisruptionBudgetUpdateAction(ns string, podDisruptionBudget *policyv1beta1.PodDisruptionBudget) kubetesting.UpdateActionImpl {
+func newPodDisruptionBudgetUpdateAction(ns string, podDisruptionBudget *policyv1.PodDisruptionBudget) kubetesting.UpdateActionImpl {
 	return kubetesting.NewUpdateAction(podDisruptionBudgetsGroup, ns, podDisruptionBudget)
 }
 
@@ -30,12 +28,12 @@ func newPodDisruptionBudgetGetAction(ns, name string) kubetesting.GetActionImpl 
 	return kubetesting.NewGetAction(podDisruptionBudgetsGroup, ns, name)
 }
 
-func newPodDisruptionBudgetCreateAction(ns string, podDisruptionBudget *policyv1beta1.PodDisruptionBudget) kubetesting.CreateActionImpl {
+func newPodDisruptionBudgetCreateAction(ns string, podDisruptionBudget *policyv1.PodDisruptionBudget) kubetesting.CreateActionImpl {
 	return kubetesting.NewCreateAction(podDisruptionBudgetsGroup, ns, podDisruptionBudget)
 }
 
 func TestPodDisruptionBudgetServiceGetCreateOrUpdate(t *testing.T) {
-	testPodDisruptionBudget := &policyv1beta1.PodDisruptionBudget{
+	testPodDisruptionBudget := &policyv1.PodDisruptionBudget{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            "testpodDisruptionBudget1",
 			ResourceVersion: "10",
@@ -46,8 +44,8 @@ func TestPodDisruptionBudgetServiceGetCreateOrUpdate(t *testing.T) {
 
 	tests := []struct {
 		name                         string
-		podDisruptionBudget          *policyv1beta1.PodDisruptionBudget
-		getPodDisruptionBudgetResult *policyv1beta1.PodDisruptionBudget
+		podDisruptionBudget          *policyv1.PodDisruptionBudget
+		getPodDisruptionBudgetResult *policyv1.PodDisruptionBudget
 		errorOnGet                   error
 		errorOnCreation              error
 		expActions                   []kubetesting.Action


### PR DESCRIPTION
Summary
=======

Closes: https://nitro.powerhrg.com/runway/backlog_items/FVR-76

Fix Pod Disruption Budget API deprecation warning on Kube 1.21+

Cluster Info
-------------

```
$ pac "kubectl --context kind-test --namespace redis-operator-test version"
Client Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.14", GitCommit:"0f77da5bd4809927e15d1658fb4aa8f13ad890a5", GitTreeState:"clean", BuildDate:"2022-06-15T14:17:29Z", GoVersion:"go1.16.15", Compiler:"gc", Platform:"linux/arm64"}
Server Version: version.Info{Major:"1", Minor:"21", GitVersion:"v1.21.14", GitCommit:"0f77da5bd4809927e15d1658fb4aa8f13ad890a5", GitTreeState:"clean", BuildDate:"2023-06-15T02:44:26Z", GoVersion:"go1.16.15", Compiler:"gc", Platform:"linux/arm64"}
```


Before - `image: image-registry.powerapp.cloud/redis-operator/spotahome:v1.7.0`:
-------------

```
$ pac "kubectl --context kind-test --namespace redis-operator-test logs pod/redis-operator-5968cd8775-h2zm4"
time="2023-11-13T17:23:17Z" level=info msg="Listening on :9710 for metrics exposure on URL /metrics" src="asm_arm64.s:1172"
time="2023-11-13T17:23:17Z" level=info msg="running in leader election mode, waiting to acquire leadership..." leader-election-id=redis-operator-test/redis-failover-lease operator=redisfailover source-service=kooper/leader-election src="controller.go:231"
I1113 17:23:17.220227       1 leaderelection.go:245] attempting to acquire leader lease redis-operator-test/redis-failover-lease...
I1113 17:23:42.038201       1 leaderelection.go:255] successfully acquired lease redis-operator-test/redis-failover-lease
time="2023-11-13T17:23:42Z" level=info msg="lead acquire, starting..." leader-election-id=redis-operator-test/redis-failover-lease operator=redisfailover source-service=kooper/leader-election src="asm_arm64.s:1172"
time="2023-11-13T17:23:42Z" level=info msg="starting controller" controller-id=redisfailover operator=redisfailover service=kooper.controller src="controller.go:232"
W1113 17:23:42.196782       1 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W1113 17:23:42.198458       1 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W1113 17:23:42.204042       1 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
W1113 17:23:42.205349       1 warnings.go:70] policy/v1beta1 PodDisruptionBudget is deprecated in v1.21+, unavailable in v1.25+; use policy/v1 PodDisruptionBudget
```

After - `image: image-registry.powerapp.cloud/redis-operator/spotahome:4adbb091f1f4bd4a96db513613655b5a3fcbf028`:
-------------

```
$ pac "kubectl --context kind-test --namespace redis-operator-test logs pods/redis-operator-6f875b859b-fbwlm"
time="2023-11-13T17:35:55Z" level=info msg="Listening on :9710 for metrics exposure on URL /metrics" src="asm_arm64.s:1172"
time="2023-11-13T17:35:55Z" level=info msg="running in leader election mode, waiting to acquire leadership..." leader-election-id=redis-operator-test/redis-failover-lease operator=redisfailover source-service=kooper/leader-election src="controller.go:231"
I1113 17:35:55.422063       1 leaderelection.go:245] attempting to acquire leader lease redis-operator-test/redis-failover-lease...
I1113 17:36:19.989453       1 leaderelection.go:255] successfully acquired lease redis-operator-test/redis-failover-lease
time="2023-11-13T17:36:19Z" level=info msg="lead acquire, starting..." leader-election-id=redis-operator-test/redis-failover-lease operator=redisfailover source-service=kooper/leader-election src="asm_arm64.s:1172"
time="2023-11-13T17:36:19Z" level=info msg="starting controller" controller-id=redisfailover operator=redisfailover service=kooper.controller src="controller.go:232"
time="2023-11-13T17:39:20Z" level=warning msg="Slave not associated to master: slave 10.244.0.41 don't have the master 10.244.0.33, has 127.0.0.1" namespace=redis-operator-test redisfailover=redis src="handler.go:118"
time="2023-11-13T17:39:20Z" level=info msg="Making pod rfr-redis-0 slave of 10.244.0.33" namespace=redis-operator-test redisfailover=redis service=redis.healer src="checker.go:197"
time="2023-11-13T17:39:20Z" level=info msg="Making pod rfr-redis-2 slave of 10.244.0.33" namespace=redis-operator-test redisfailover=redis service=redis.healer src="checker.go:197"
```