### PR TITLE
Add kube 1.12.14 to integration-tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -38,7 +38,12 @@ jobs:
     needs: [check, unit-test]
     strategy:
       matrix:
-        kubernetes: [1.24.16, 1.25.12, 1.26.7, 1.27.3 ]
+        kubernetes:
+          - 1.21.14
+          - 1.24.16
+          - 1.25.12
+          - 1.26.7
+          - 1.27.3
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4


### PR DESCRIPTION
Summary
============

Add the current PAC kube version to the testing matrix.

Context
==========

The integration test suite doesn't test the operator against the version of kube we use internally. While we ARE actively upgrading our clusters, we _ought_ to make sure the integration tests are run against the versions of kube we intend to support. This change adds said version to the testing matrix.

Part of: https://nitro.powerhrg.com/runway/backlog_items/FVR-93