### PR TITLE
Fix generated mocks

### DIFF
--- a/mocks/service/k8s/Services.go
+++ b/mocks/service/k8s/Services.go
@@ -12,6 +12,7 @@ import (
 	mock "github.com/stretchr/testify/mock"
 
 	networkingv1 "k8s.io/api/networking/v1"
+
 	policyv1 "k8s.io/api/policy/v1"
 
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -553,6 +554,10 @@ func (_m *Services) GetPodDisruptionBudget(namespace string, name string) (*poli
 	ret := _m.Called(namespace, name)
 
 	var r0 *policyv1.PodDisruptionBudget
+	var r1 error
+	if rf, ok := ret.Get(0).(func(string, string) (*policyv1.PodDisruptionBudget, error)); ok {
+		return rf(namespace, name)
+	}
 	if rf, ok := ret.Get(0).(func(string, string) *policyv1.PodDisruptionBudget); ok {
 		r0 = rf(namespace, name)
 	} else {

--- a/test/integration/redisfailover/creation_test.go
+++ b/test/integration/redisfailover/creation_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
@@ -161,6 +162,8 @@ func TestRedisFailover(t *testing.T) {
 	t.Run("Check Sentinels Checking the Redis Master", clients.testSentinelMonitoring)
 }
 
+const sentinelPort = 26379
+
 func (c *clients) testCRCreation(t *testing.T) {
 	assert := assert.New(t)
 	toCreate := &redisfailoverv1.RedisFailover{
@@ -178,7 +181,7 @@ func (c *clients) testCRCreation(t *testing.T) {
 			},
 			Sentinel: redisfailoverv1.SentinelSettings{
 				Replicas: sentinelSize,
-				Port:     redisfailoverv1.Port(26379),
+				Port:     redisfailoverv1.Port(sentinelPort),
 			},
 			Auth: redisfailoverv1.AuthSettings{
 				SecretPath: authSecretPath,
@@ -247,7 +250,9 @@ func (c *clients) testSentinelMonitoring(t *testing.T) {
 
 	for _, pod := range sentinelPodList.Items {
 		ip := pod.Status.PodIP
-		master, _, _ := c.redisClient.GetSentinelMonitor(ip)
+		port := strconv.FormatInt(int64(sentinelPort), 10)
+
+		master, _, _ := c.redisClient.GetSentinelMonitor(ip, port)
 		masters = append(masters, master)
 	}
 


### PR DESCRIPTION
Part of: https://nitro.powerhrg.com/runway/backlog_items/FVR-93

Fix the generated mocks
=======================

`make test` is currently failing because the generated mock references an undefined variable:
```
Error: mocks/service/k8s/Services.go:565:3: undefined: r1
Error: mocks/service/k8s/Services.go:567:3: undefined: r1
Error: mocks/service/k8s/Services.go:570:13: undefined: r1
```

This was probably introduced in merge from the upstream and not caught because we're still in the process of setting CI in this fork. 


Fix the integration tests
==========================

The integration tests have also been broken since we added a configurable port to the Sentinels:

```
 # github.com/spotahome/redis-operator/test/integration/redisfailover_test [github.com/spotahome/redis-operator/test/integration/redisfailover.test]
Error: test/integration/redisfailover/creation_test.go:250:52: not enough arguments in call to c.redisClient.GetSentinelMonitor
	have (string)
	want (string, string)
FAIL	github.com/spotahome/redis-operator/test/integration/redisfailover [build failed]
FAIL
make: *** [Makefile:142: ci-integration-test] Error 1
Error: Process completed with exit code 2.
```

