### PR TITLE
Use more targeted NetworkPolicies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ Check [releases](https://github.com/spotahome/redis-operator/releases) section f
 
 ## Unreleased
 
+- [Use finer grained NetworkPolicies](https://github.com/powerhome/redis-operator/pull/25)
 - [Fix PodDisruptionBudget deprecation warnings on kube 1.21+](https://github.com/powerhome/redis-operator/pull/19)
 
 ## [v1.1.0-rc.3] - 2022-01-19

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v1.3.0-rc0
+VERSION := v1.7.1-rc1
 
 # Name of this service/application
 SERVICE_NAME := redis-operator
@@ -31,11 +31,11 @@ BRANCH=$(shell git rev-parse --abbrev-ref HEAD)
 
 TAG := $(GITTAG)
 ifneq ($(COMMIT), $(GITTAG_COMMIT))
-    TAG := $(COMMIT)
+	TAG := $(COMMIT)
 endif
 
 ifneq ($(shell git status --porcelain),)
-    TAG := $(TAG)-dirty
+	TAG := $(TAG)-dirty
 endif
 
 

--- a/mocks/operator/redisfailover/service/RedisFailoverClient.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverClient.go
@@ -56,20 +56,6 @@ func (_m *RedisFailoverClient) EnsureHAProxyService(rFailover *v1.RedisFailover,
 	return r0
 }
 
-// EnsureNetworkPolicy provides a mock function with given fields: rFailover, labels, ownerRefs
-func (_m *RedisFailoverClient) EnsureNetworkPolicy(rFailover *v1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
-	ret := _m.Called(rFailover, labels, ownerRefs)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*v1.RedisFailover, map[string]string, []metav1.OwnerReference) error); ok {
-		r0 = rf(rFailover, labels, ownerRefs)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // EnsureNotPresentRedisService provides a mock function with given fields: rFailover
 func (_m *RedisFailoverClient) EnsureNotPresentRedisService(rFailover *v1.RedisFailover) error {
 	ret := _m.Called(rFailover)
@@ -114,6 +100,20 @@ func (_m *RedisFailoverClient) EnsureRedisHeadlessService(rFailover *v1.RedisFai
 
 // EnsureRedisMasterService provides a mock function with given fields: rFailover, labels, ownerRefs
 func (_m *RedisFailoverClient) EnsureRedisMasterService(rFailover *v1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
+	ret := _m.Called(rFailover, labels, ownerRefs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.RedisFailover, map[string]string, []metav1.OwnerReference) error); ok {
+		r0 = rf(rFailover, labels, ownerRefs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// EnsureRedisNetworkPolicy provides a mock function with given fields: rFailover, labels, ownerRefs
+func (_m *RedisFailoverClient) EnsureRedisNetworkPolicy(rFailover *v1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
 	ret := _m.Called(rFailover, labels, ownerRefs)
 
 	var r0 error
@@ -212,6 +212,20 @@ func (_m *RedisFailoverClient) EnsureSentinelConfigMap(rFailover *v1.RedisFailov
 
 // EnsureSentinelDeployment provides a mock function with given fields: rFailover, labels, ownerRefs
 func (_m *RedisFailoverClient) EnsureSentinelDeployment(rFailover *v1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
+	ret := _m.Called(rFailover, labels, ownerRefs)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.RedisFailover, map[string]string, []metav1.OwnerReference) error); ok {
+		r0 = rf(rFailover, labels, ownerRefs)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// EnsureSentinelNetworkPolicy provides a mock function with given fields: rFailover, labels, ownerRefs
+func (_m *RedisFailoverClient) EnsureSentinelNetworkPolicy(rFailover *v1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
 	ret := _m.Called(rFailover, labels, ownerRefs)
 
 	var r0 error

--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -20,7 +20,10 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels 
 	}
 
 	if !(len(rf.Spec.NetworkPolicyNsList) == 0) {
-		if err := w.rfService.EnsureNetworkPolicy(rf, labels, or); err != nil {
+		if err := w.rfService.EnsureRedisNetworkPolicy(rf, labels, or); err != nil {
+			return err
+		}
+		if err := w.rfService.EnsureSentinelNetworkPolicy(rf, labels, or); err != nil {
 			return err
 		}
 	}

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -18,7 +18,8 @@ type RedisFailoverClient interface {
 	EnsureHAProxyConfigmap(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
 	EnsureHAProxyService(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
 	EnsureRedisHeadlessService(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
-	EnsureNetworkPolicy(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
+	EnsureRedisNetworkPolicy(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
+	EnsureSentinelNetworkPolicy(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
 	EnsureSentinelService(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
 	EnsureSentinelConfigMap(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
 	EnsureSentinelDeployment(rFailover *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error
@@ -80,11 +81,19 @@ func generateComponentLabel(componentType string) map[string]string {
 	}
 }
 
-// EnsureNetworkPolicy makes sure the network policy exists
-func (r *RedisFailoverKubeClient) EnsureNetworkPolicy(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
-	svc := generateNetworkPolicy(rf, labels, ownerRefs)
+// EnsureRedisNetworkPolicy makes sure the redis network policy exists
+func (r *RedisFailoverKubeClient) EnsureRedisNetworkPolicy(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
+	svc := generateRedisNetworkPolicy(rf, labels, ownerRefs)
 	err := r.K8SService.CreateOrUpdateNetworkPolicy(rf.Namespace, svc)
-	r.setEnsureOperationMetrics(svc.Namespace, svc.Name, "NetworkPolicy", rf.Name, err)
+	r.setEnsureOperationMetrics(svc.Namespace, svc.Name, "EnsureRedisNetworkPolicy", rf.Name, err)
+	return err
+}
+
+// EnsureSentinelNetworkPolicy makes sure the redis network policy exists
+func (r *RedisFailoverKubeClient) EnsureSentinelNetworkPolicy(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
+	svc := generateSentinelNetworkPolicy(rf, labels, ownerRefs)
+	err := r.K8SService.CreateOrUpdateNetworkPolicy(rf.Namespace, svc)
+	r.setEnsureOperationMetrics(svc.Namespace, svc.Name, "EnsureSentinelNetworkPolicy", rf.Name, err)
 	return err
 }
 

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -14,20 +14,21 @@ const (
 )
 
 const (
-	baseName               = "rf"
-	sentinelName           = "s"
-	sentinelRoleName       = "sentinel"
-	sentinelConfigFileName = "sentinel.conf"
-	redisConfigFileName    = "redis.conf"
-	redisName              = "r"
-	redisMasterName        = "rm"
-	redisSlaveName         = "rs"
-	redisShutdownName      = "r-s"
-	redisReadinessName     = "r-readiness"
-	redisRoleName          = "redis"
-	appLabel               = "redis-failover"
-	hostnameTopologyKey    = "kubernetes.io/hostname"
-	networkPolicyName      = "network-policy"
+	baseName                  = "rf"
+	sentinelName              = "s"
+	sentinelRoleName          = "sentinel"
+	sentinelConfigFileName    = "sentinel.conf"
+	sentinelNetworkPolicyName = "s-np"
+	redisConfigFileName       = "redis.conf"
+	redisName                 = "r"
+	redisNetworkPolicyName    = "r-np"
+	redisMasterName           = "rm"
+	redisSlaveName            = "rs"
+	redisShutdownName         = "r-s"
+	redisReadinessName        = "r-readiness"
+	redisRoleName             = "redis"
+	appLabel                  = "redis-failover"
+	hostnameTopologyKey       = "kubernetes.io/hostname"
 )
 
 const (

--- a/operator/redisfailover/service/names.go
+++ b/operator/redisfailover/service/names.go
@@ -34,9 +34,14 @@ func GetSentinelName(rf *redisfailoverv1.RedisFailover) string {
 	return generateName(sentinelName, rf.Name)
 }
 
-// GetSentinelName returns the name for sentinel resources
-func GetNetworkPolicyName(rf *redisfailoverv1.RedisFailover) string {
-	return generateName(networkPolicyName, rf.Name)
+// GetRedisNetworkPolicyName returns the name for the redis network policy
+func GetRedisNetworkPolicyName(rf *redisfailoverv1.RedisFailover) string {
+	return generateName(redisNetworkPolicyName, rf.Name)
+}
+
+// GetSentinelNetworkPolicyName returns the name for the sentinel network policy
+func GetSentinelNetworkPolicyName(rf *redisfailoverv1.RedisFailover) string {
+	return generateName(sentinelNetworkPolicyName, rf.Name)
 }
 
 func GetRedisMasterName(rf *redisfailoverv1.RedisFailover) string {


### PR DESCRIPTION
In #4, we added a NetworkPolicy. The intent was to prevent the Redis and/or Sentinel pods from differing RedisFailovers from joining up with one another (See: https://github.com/spotahome/redis-operator/issues/550). These policies have proven to be too coarsely grained. We end up deploying supplemental NetworkPolicies to allow ingress traffic. 

This change narrows the scope of the NetworkPolicies manged by the operator. One policy allows traffic to the Redis node pods ONLY on the redis port and monitoring port for traffic originating from within the namespace. The other policy allows traffic to the Sentinel pods ONLY on the sentinel port for traffic originating from within the namespace. All other traffic to these pods will be dropped. 

Connections to the HAProxy pods - IE access to the redis master node - will now be allowed by default. This achieves the goals of #4 and allows us to stop littering additional NetworkPolicies to allow external communication with a Redis instance.