### PR TITLE
Setup public image repository

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Check [releases](https://github.com/powerhome/redis-operator/releases) section f
 
 ## Unreleased
 
+## [v1.8.0-rc1] - 2023-12-15
+
+- [Add public image repository](https://github.com/powerhome/redis-operator/pull/28)
+
 ## [v1.7.1] - 2023-12-14
 
 - [Use finer grained NetworkPolicies](https://github.com/powerhome/redis-operator/pull/25)

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-VERSION := v1.7.1
+VERSION := v1.8.0-rc1
 
 # Name of this service/application
 SERVICE_NAME := redis-operator
 
 # Docker image name for this project
-IMAGE_NAME := spotahome/$(SERVICE_NAME)
+IMAGE_NAME := powerhome/$(SERVICE_NAME)
 
 # Repository url for this project
-REPOSITORY := quay.io/$(IMAGE_NAME)
+REPOSITORY := $(IMAGE_NAME)
 
 # Shell to use for running scripts
 SHELL := $(shell which bash)


### PR DESCRIPTION
Updates make targets to produce public powerhome/redis-operator images at https://hub.docker.com/r/powerhome/redis-operator