### PR TITLE
Run ci on the master branch

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,7 +3,7 @@ name: CI
 on:
   push:
     branches:
-      - main
+      - master
   pull_request:
 
 jobs:


### PR DESCRIPTION
 The CI workflow has always intended to run when the master branch changes, however the workflow definition is targeting the wrong branch name. 

With this change, CI should run on the head commits of all PRs, AND the master branch.