### PR TITLE
Automate image publishing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,9 +106,7 @@ jobs:
         with:
           images: powerhome/redis-operator
           tags: |
-            type=ref,event=tag
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{raw}}
             type=sha,prefix=,suffix=,format=long
       - name: Login to DockerHub
         uses: docker/login-action@v3

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,6 @@
 name: CI
 
 on:
-  workflow_dispatch:
   push:
     branches:
       - 'master'
@@ -10,6 +9,9 @@ on:
   pull_request:
     branches:
       - 'master'
+
+env:
+  DOCKER_METADATA_PR_HEAD_SHA: true
 
 jobs:
   check:
@@ -40,7 +42,9 @@ jobs:
   integration-test:
     name: Integration test
     runs-on: ubuntu-latest
-    needs: [check, unit-test]
+    needs:
+      - check
+      - unit-test
     strategy:
       matrix:
         kubernetes:
@@ -83,23 +87,39 @@ jobs:
         run: make helm-test
 
   dockerhub-image:
-    needs: [check, unit-test, integration-test]
+    needs:
+      - check
+      - unit-test
+      - integration-test
     runs-on: ubuntu-latest
     steps:
       -
         name: Checkout
         uses: actions/checkout@v4
-      - name: Checkout
-        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      -
-        name: Login to DockerHub
+      - name: Docker Metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: powerhome/redis-operator
+          tags: |
+            type=ref,event=tag
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=sha,prefix=,suffix=,format=long
+      - name: Login to DockerHub
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and Release Image
-        run: make image-release
+      - name: Build
+        uses: docker/bake-action@v3
+        with:
+          files: |
+            ./docker-bake.hcl
+            ${{ steps.meta.outputs.bake-file }}
+          targets: build
+          push: true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,15 @@
 name: CI
 
 on:
+  workflow_dispatch:
   push:
     branches:
-      - master
+      - 'master'
+    tags:
+      - 'v*'
   pull_request:
+    branches:
+      - 'master'
 
 jobs:
   check:
@@ -76,3 +81,25 @@ jobs:
 
       - name: Helm test
         run: make helm-test
+
+  dockerhub-image:
+    needs: [check, unit-test, integration-test]
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and Release Image
+        run: make image-release

--- a/Makefile
+++ b/Makefile
@@ -98,35 +98,9 @@ image: deps-development
 	-f $(APP_DIR)/Dockerfile \
 	.
 
-.PHONY: image-release
-image-release:
-	docker buildx build \
-	--platform linux/amd64,linux/arm64,linux/arm/v7 \
-	--push \
-	--build-arg VERSION=$(TAG) \
-	-t $(REPOSITORY):latest \
-	-t $(REPOSITORY):$(COMMIT) \
-	-t $(REPOSITORY):$(TAG) \
-	-f $(APP_DIR)/Dockerfile \
-	.
-
-.PHONY: testing
-testing: image
-	docker push $(REPOSITORY):$(BRANCH)
-
 .PHONY: tag
 tag:
 	git tag $(VERSION)
-
-.PHONY: publish
-publish:
-	@COMMIT_VERSION="$$(git rev-list -n 1 $(VERSION))"; \
-	docker tag $(REPOSITORY):"$$COMMIT_VERSION" $(REPOSITORY):$(VERSION)
-	docker push $(REPOSITORY):$(VERSION)
-	docker push $(REPOSITORY):latest
-
-.PHONY: release
-release: tag image-release
 
 # Test stuff in dev
 .PHONY: unit-test

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v1.8.0-rc2
+VERSION := v1.8.0-rc3
 
 # Name of this service/application
 SERVICE_NAME := redis-operator

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v1.8.0-rc1
+VERSION := v1.8.0-rc2
 
 # Name of this service/application
 SERVICE_NAME := redis-operator

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,28 @@
+// Special target: https://github.com/docker/metadata-action#bake-definition
+target "docker-metadata-action" {}
+
+// Default target if none specified
+group "default" {
+  targets = ["build-local"]
+}
+
+target "operator" {
+  inherits = ["docker-metadata-action"]
+  dockerfile = "docker/app/Dockerfile"
+}
+
+target "build-local" {
+  inherits = ["operator"]
+  output = ["type=docker"]
+}
+
+target "build" {
+  inherits = ["operator"]
+  platforms = [
+    "linux/amd64",
+    "linux/arm/v6",
+    "linux/arm/v7",
+    "linux/arm64",
+    "linux/386"
+  ]
+}


### PR DESCRIPTION
Add Github Actions to build and publish images to the [public docker hub image repository](https://hub.docker.com/repository/docker/powerhome/redis-operator/general).

Images are built only for commits with passing linter, unit and integration test checks.

Images are built for...:

- the HEAD commits of PR branches where the base branch is `master`. An image tag with the PR Branch's HEAD commit's git SHA will be produced.
- merges into the `master` branch. An image tag with the `master` branch's HEAD commit's git SHA will be produced.
- new tags pushed into the Github repository. An image tag with the git tag's name will be produced.

Changes of note:

The replaces the `Makefile` targets intended to build and push images. Instead we'll rely on the publicly available Github Actions published by the Docker project.

This also simplifies the collection and publishing of image metadata - tags, labels, annotations, etc. The `Makefile` targets were tagging images based off of the detached merge commit created by the Github Action - IE the tags were not traceable to any code artifacts. Additionally the images produced by the `Makefile` targets did NOT produce any metadata about the image - its provenance, creation timestamps, license information, etc.

The [`docker/metdata-action`](https://github.com/docker/metadata-action) captures this metadata for us now and [bakes](https://docs.docker.com/engine/reference/commandline/buildx_bake/) it into the image using the [`docker/bake-action`](https://github.com/docker/bake-action).

``` text
$ docker pull powerhome/redis-operator:v1.8.0-rc3 && docker image inspect powerhome/redis-operator:v1.8.0-rc3 | jq .[].Config.Labels
v1.8.0-rc3: Pulling from powerhome/redis-operator
Digest: sha256:a7828b31aca85d8623d30a5e4e7335cc7d87a03283c7700badfa8cc94b4996d6
Status: Image is up to date for powerhome/redis-operator:v1.8.0-rc3
docker.io/powerhome/redis-operator:v1.8.0-rc3

...
{
  "org.opencontainers.image.created": "2023-12-20T18:21:06.367Z",
  "org.opencontainers.image.description": "Redis Operator creates/configures/manages high availability redis with sentinel automatic failover atop Kubernetes.",
  "org.opencontainers.image.licenses": "Apache-2.0",
  "org.opencontainers.image.revision": "36b8c3b5932b1a007789ec16942dd006eb0816f2",
  "org.opencontainers.image.source": "https://github.com/powerhome/redis-operator",
  "org.opencontainers.image.title": "redis-operator",
  "org.opencontainers.image.url": "https://github.com/powerhome/redis-operator",
  "org.opencontainers.image.version": "v1.8.0-rc3"
}

```

This required us to provide a `docker-bake.hcl` to describe the target platforms which were previously passed in by the `Makefile`.

In a future iteration, I'd like to try to extract a generic "Publish Image to Docker Hub" workflow and publish it as part of https://github.com/powerhome/github-actions-workflows then reference it here, but figured I'd stop here since this currently delivers on the intended goal.