### PR TITLE
Expose HAProxy metrics exporter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,16 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
+### Added
+
+- Expose harproxy prometheus exporter metrics on port
+
 ### Changed
 - [Use the new docker bake tooling to build the developer tools image and remove vestigial development targets from the Makefile](https://github.com/powerhome/redis-operator/pull/31).
+
+### Fixed
+
+- Fix haproxy pod labels so they aren't included in the redis headless service
 
 ## [v1.8.0-rc2] - 2023-12-20
 

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -16,6 +16,7 @@ const (
 
 const (
 	baseName                  = "rf"
+	haproxyRoleName           = "haproxy"
 	sentinelName              = "s"
 	sentinelRoleName          = "sentinel"
 	sentinelConfigFileName    = "sentinel.conf"

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -4,6 +4,7 @@ package service
 const (
 	exporterPort                  = 9121
 	sentinelExporterPort          = 9355
+	haproxyExporterPort           = 9405
 	exporterPortName              = "http-metrics"
 	exporterContainerName         = "redis-exporter"
 	sentinelExporterContainerName = "sentinel-exporter"

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -58,11 +58,8 @@ func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[str
 
 	namespace := rf.Namespace
 
-	labels = util.MergeLabels(labels, map[string]string{
-		"app.kubernetes.io/component": "redis",
-	})
-
-	selectorLabels := util.MergeLabels(labels, generateComponentLabel("haproxy"))
+	labels = util.MergeLabels(labels, generateComponentLabel(haproxyRoleName))
+	selectorLabels := util.MergeLabels(labels)
 
 	volumeMounts := []corev1.VolumeMount{
 		{

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -58,8 +58,9 @@ func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[str
 
 	namespace := rf.Namespace
 
+	selectorLabels := generateSelectorLabels(haproxyRoleName, rf.Name)
+	labels = util.MergeLabels(labels, selectorLabels)
 	labels = util.MergeLabels(labels, generateComponentLabel(haproxyRoleName))
-	selectorLabels := util.MergeLabels(labels)
 
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -97,7 +98,7 @@ func generateHAProxyDeployment(rf *redisfailoverv1.RedisFailover, labels map[str
 			},
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: selectorLabels,
+					Labels: labels,
 				},
 				Spec: corev1.PodSpec{
 					Containers: []corev1.Container{
@@ -250,11 +251,9 @@ func generateHAProxyService(rf *redisfailoverv1.RedisFailover, labels map[string
 	}
 	namespace := rf.Namespace
 	redisTargetPort := intstr.FromInt(int(rf.Spec.Redis.Port))
-	selectorLabels := map[string]string{
-		"app.kubernetes.io/component": "redis",
-	}
-	selectorLabels = util.MergeLabels(selectorLabels, generateComponentLabel("haproxy"))
-	selectorLabels = util.MergeLabels(labels, selectorLabels)
+	selectorLabels := generateSelectorLabels(haproxyRoleName, rf.Name)
+	selectorLabels = util.MergeLabels(selectorLabels, generateComponentLabel(haproxyRoleName))
+	labels = util.MergeLabels(labels, selectorLabels)
 
 	spec := corev1.ServiceSpec{
 		Selector: selectorLabels,

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -1319,11 +1319,19 @@ func TestHaproxyService(t *testing.T) {
 							Name: "testing",
 						},
 					},
+					Labels: map[string]string{
+						"app.kubernetes.io/component":                      "haproxy",
+						"app.kubernetes.io/name":                           name,
+						"app.kubernetes.io/part-of":                        "redis-failover",
+						"redisfailovers.databases.spotahome.com/component": "haproxy",
+					},
 				},
 				Spec: corev1.ServiceSpec{
 					Type: corev1.ServiceTypeClusterIP,
 					Selector: map[string]string{
-						"app.kubernetes.io/component":                      "redis",
+						"app.kubernetes.io/component":                      "haproxy",
+						"app.kubernetes.io/name":                           name,
+						"app.kubernetes.io/part-of":                        "redis-failover",
 						"redisfailovers.databases.spotahome.com/component": "haproxy",
 					},
 					Ports: []corev1.ServicePort{
@@ -1361,12 +1369,20 @@ func TestHaproxyService(t *testing.T) {
 							Name: "testing",
 						},
 					},
+					Labels: map[string]string{
+						"app.kubernetes.io/component":                      "haproxy",
+						"app.kubernetes.io/name":                           name,
+						"app.kubernetes.io/part-of":                        "redis-failover",
+						"redisfailovers.databases.spotahome.com/component": "haproxy",
+					},
 				},
 				Spec: corev1.ServiceSpec{
 					Type:      corev1.ServiceTypeClusterIP,
 					ClusterIP: "10.1.1.100",
 					Selector: map[string]string{
-						"app.kubernetes.io/component":                      "redis",
+						"app.kubernetes.io/component":                      "haproxy",
+						"app.kubernetes.io/name":                           name,
+						"app.kubernetes.io/part-of":                        "redis-failover",
 						"redisfailovers.databases.spotahome.com/component": "haproxy",
 					},
 					Ports: []corev1.ServicePort{


### PR DESCRIPTION
Summary
-------

In order to better understand the health / performance of RedisFailover Custom Resources we want the ability to instrument and monitor the haproxy component.

Context
-------

[HAProxy is compiled with a prometheus-style metrics exporter](https://www.haproxy.com/documentation/hapee/latest/observability/metrics/prometheus/). 

```
$ haproxy -vv 
...
Available services : prometheus-exporter
```

This makes the haproxy pods and ClusterIP service expose the metrics on port 9405