### PR TITLE
Run make generate to fix DestroySentinelResource

### DIFF
--- a/mocks/operator/redisfailover/service/RedisFailoverClient.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverClient.go
@@ -14,6 +14,20 @@ type RedisFailoverClient struct {
 	mock.Mock
 }
 
+// DestroySentinelResources provides a mock function with given fields: rFailover
+func (_m *RedisFailoverClient) DestroySentinelResources(rFailover *v1.RedisFailover) error {
+	ret := _m.Called(rFailover)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.RedisFailover) error); ok {
+		r0 = rf(rFailover)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // EnsureHAProxyConfigmap provides a mock function with given fields: rFailover, labels, ownerRefs
 func (_m *RedisFailoverClient) EnsureHAProxyConfigmap(rFailover *v1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) error {
 	ret := _m.Called(rFailover, labels, ownerRefs)
@@ -217,20 +231,6 @@ func (_m *RedisFailoverClient) EnsureSentinelDeployment(rFailover *v1.RedisFailo
 	var r0 error
 	if rf, ok := ret.Get(0).(func(*v1.RedisFailover, map[string]string, []metav1.OwnerReference) error); ok {
 		r0 = rf(rFailover, labels, ownerRefs)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
-// DestroySentinelResources provides a mock function with given fields: rFailover, labels, ownerRefs
-func (_m *RedisFailoverClient) DestroySentinelResources(rFailover *v1.RedisFailover) error {
-	ret := _m.Called(rFailover)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(*v1.RedisFailover) error); ok {
-		r0 = rf(rFailover)
 	} else {
 		r0 = ret.Error(0)
 	}


### PR DESCRIPTION
Ran the `make generate` target locally while preparing a branch for the 1.8.0 release. I'm not entirely sure what happened, but the client generator wants to move and fix the documentation of the `DestroySentinelResources` method that was added in https://github.com/powerhome/redis-operator/pull/33.