### PR TITLE
Add default haproxy image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
+- Add default haproxy image #47
+
 ## [v2.0.2] - 2024-02-13
 
 ### Fixed

--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -6,6 +6,7 @@ const (
 	defaultSentinelExporterImage = "quay.io/oliver006/redis_exporter:v1.43.0"
 	defaultExporterImage         = "quay.io/oliver006/redis_exporter:v1.43.0"
 	defaultImage                 = "redis:6.2.6-alpine"
+	defaultHAProxyImage          = "haproxy:2.4"
 	defaultRedisPort             = 6379
 )
 

--- a/api/redisfailover/v1/validate.go
+++ b/api/redisfailover/v1/validate.go
@@ -67,6 +67,12 @@ func (r *RedisFailover) Validate() error {
 		r.Spec.Sentinel.CustomConfig = defaultSentinelCustomConfig
 	}
 
+	if r.Spec.Haproxy != nil {
+		if r.Spec.Haproxy.Image == "" {
+			r.Spec.Haproxy.Image = defaultHAProxyImage
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Sets a default HAProxy image when one is not specified in the RedisFailover CR. When the RedisFailover includes a HAProxy Spec, the operator errors unless an Image attribute is present. 