### PR TITLE
Remove orphaned network policy resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
+### Fixed
+
+- [In version 2.0.1, the approach to generating network policy by the operator was modified. From v2.0.1 onwards, the operator no longer creates network policy for redis but continues to do it for sentinels. This fix automatically removes any leftover network policy from the namespace, eliminating the need for manual intervention](https://github.com/powerhome/redis-operator/pull/49)
+
 ### Changed
 
 - Add default haproxy image #47

--- a/mocks/operator/redisfailover/service/RedisFailoverClient.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverClient.go
@@ -14,6 +14,20 @@ type RedisFailoverClient struct {
 	mock.Mock
 }
 
+// DestroyRemainedRedisNetworkPolicy provides a mock function with given fields: rFailover
+func (_m *RedisFailoverClient) DestroyRemainedRedisNetworkPolicy(rFailover *v1.RedisFailover) error {
+	ret := _m.Called(rFailover)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.RedisFailover) error); ok {
+		r0 = rf(rFailover)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DestroySentinelResources provides a mock function with given fields: rFailover
 func (_m *RedisFailoverClient) DestroySentinelResources(rFailover *v1.RedisFailover) error {
 	ret := _m.Called(rFailover)

--- a/mocks/operator/redisfailover/service/RedisFailoverClient.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverClient.go
@@ -14,8 +14,8 @@ type RedisFailoverClient struct {
 	mock.Mock
 }
 
-// DestroyRemainedRedisNetworkPolicy provides a mock function with given fields: rFailover
-func (_m *RedisFailoverClient) DestroyRemainedRedisNetworkPolicy(rFailover *v1.RedisFailover) error {
+// DestroySentinelResources provides a mock function with given fields: rFailover
+func (_m *RedisFailoverClient) DestroySentinelResources(rFailover *v1.RedisFailover) error {
 	ret := _m.Called(rFailover)
 
 	var r0 error
@@ -28,8 +28,8 @@ func (_m *RedisFailoverClient) DestroyRemainedRedisNetworkPolicy(rFailover *v1.R
 	return r0
 }
 
-// DestroySentinelResources provides a mock function with given fields: rFailover
-func (_m *RedisFailoverClient) DestroySentinelResources(rFailover *v1.RedisFailover) error {
+// DestroydOrphanedRedisNetworkPolicy provides a mock function with given fields: rFailover
+func (_m *RedisFailoverClient) DestroydOrphanedRedisNetworkPolicy(rFailover *v1.RedisFailover) error {
 	ret := _m.Called(rFailover)
 
 	var r0 error

--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -25,7 +25,7 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels 
 		}
 	}
 
-	if err := w.rfService.DestroyRemainedRedisNetworkPolicy(rf); err != nil {
+	if err := w.rfService.DestroydOrphanedRedisNetworkPolicy(rf); err != nil {
 		return err
 	}
 

--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -25,6 +25,10 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels 
 		}
 	}
 
+	if err := w.rfService.DestroyRemainedRedisNetworkPolicy(rf); err != nil {
+		return err
+	}
+
 	if rf.Spec.Haproxy != nil {
 		if err := w.rfService.EnsureHAProxyRedisMasterService(rf, labels, or); err != nil {
 			return err

--- a/operator/redisfailover/ensurer_test.go
+++ b/operator/redisfailover/ensurer_test.go
@@ -151,6 +151,8 @@ func TestEnsure(t *testing.T) {
 			mrfs.On("EnsureRedisReadinessConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
 			mrfs.On("EnsureRedisStatefulset", rf, mock.Anything, mock.Anything).Once().Return(nil)
 
+			mrfs.On("DestroyRemainedRedisNetworkPolicy", rf, mock.Anything, mock.Anything).Once().Return(nil)
+
 			// Create the Kops client and call the valid logic.
 			handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)
 			err := handler.Ensure(rf, map[string]string{}, []metav1.OwnerReference{}, metrics.Dummy)

--- a/operator/redisfailover/ensurer_test.go
+++ b/operator/redisfailover/ensurer_test.go
@@ -151,7 +151,7 @@ func TestEnsure(t *testing.T) {
 			mrfs.On("EnsureRedisReadinessConfigMap", rf, mock.Anything, mock.Anything).Once().Return(nil)
 			mrfs.On("EnsureRedisStatefulset", rf, mock.Anything, mock.Anything).Once().Return(nil)
 
-			mrfs.On("DestroyRemainedRedisNetworkPolicy", rf, mock.Anything, mock.Anything).Once().Return(nil)
+			mrfs.On("DestroydOrphanedRedisNetworkPolicy", rf, mock.Anything, mock.Anything).Once().Return(nil)
 
 			// Create the Kops client and call the valid logic.
 			handler := rfOperator.NewRedisFailoverHandler(config, mrfs, mrfc, mrfh, mk, metrics.Dummy, log.Dummy)

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -219,7 +219,6 @@ func (r *RedisFailoverKubeClient) DestroyRemainedRedisNetworkPolicy(rf *redisfai
 	name := GetRedisNetworkPolicyName(rf)
 
 	if _, err := r.K8SService.GetNetworkPolicy(rf.Namespace, name); err != nil {
-		// If no resource, do nothing
 		if errors.IsNotFound(err) {
 			return nil
 		}

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -221,6 +221,8 @@ func (r *RedisFailoverKubeClient) DestroyRemainedRedisNetworkPolicy(rf *redisfai
 	if _, err := r.K8SService.GetNetworkPolicy(rf.Namespace, name); err != nil {
 		if errors.IsNotFound(err) {
 			return nil
+		} else {
+			return err
 		}
 	}
 

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -214,7 +214,7 @@ func (r *RedisFailoverKubeClient) DestroySentinelResources(rf *redisfailoverv1.R
 	return err
 }
 
-func (r *RedisFailoverKubeClient) DestroyRemainedRedisNetworkPolicy(rf *redisfailoverv1.RedisFailover) error {
+func (r *RedisFailoverKubeClient) DestroydOrphanedRedisNetworkPolicy(rf *redisfailoverv1.RedisFailover) error {
 
 	name := GetRedisNetworkPolicyName(rf)
 

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -39,7 +39,7 @@ type RedisFailoverClient interface {
 	DestroySentinelResources(rFailover *redisfailoverv1.RedisFailover) error
 	UpdateStatus(rFailover *redisfailoverv1.RedisFailover) (*redisfailoverv1.RedisFailover, error)
 
-	DestroyRemainedRedisNetworkPolicy(rFailover *redisfailoverv1.RedisFailover) error
+	DestroydOrphanedRedisNetworkPolicy(rFailover *redisfailoverv1.RedisFailover) error
 }
 
 // RedisFailoverKubeClient implements the required methods to talk with kubernetes

--- a/operator/redisfailover/service/client.go
+++ b/operator/redisfailover/service/client.go
@@ -214,7 +214,6 @@ func (r *RedisFailoverKubeClient) DestroySentinelResources(rf *redisfailoverv1.R
 	return err
 }
 
-// DestroyRemainedRedisNetworkPolicy remove remained network policy
 func (r *RedisFailoverKubeClient) DestroyRemainedRedisNetworkPolicy(rf *redisfailoverv1.RedisFailover) error {
 
 	name := GetRedisNetworkPolicyName(rf)


### PR DESCRIPTION
Fixes: https://github.com/powerhome/redis-operator/issues/48

This PR aims to address an issue introduced in release 2.0.1, where the logic for generating network policy resources by the operator was changed. From version 2.0.1 onwards, the operator no longer generates network policies for Redis but failed to remove existing policies generated prior to this version. This PR introduces a check and removal process for that leftover network policiy.