### PR TITLE
Prepare release v2.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
+## [v2.1.0] - 2024-02-26
+
 ### Fixed
 
 - [In version 2.0.1, the approach to generating network policy by the operator was modified. From v2.0.1 onwards, the operator no longer creates network policy for redis but continues to do it for sentinels. This fix automatically removes any leftover network policy from the namespace, eliminating the need for manual intervention](https://github.com/powerhome/redis-operator/pull/49)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v2.0.2
+VERSION := v2.1.0
 
 # Name of this service/application
 SERVICE_NAME := redis-operator


### PR DESCRIPTION
Prepare the repository for tagging / release of version 2.1.0.

Note, this release contains a [fix](https://github.com/powerhome/redis-operator/pull/49) for https://github.com/powerhome/redis-operator/issues/48 - hence the minor version upgrade.

References
----------

- https://semver.org/#what-do-i-do-if-i-accidentally-release-a-backward-incompatible-change-as-a-minor-version