### PR TITLE
[FVR-182] Restarting Pods Via RollingUpdate

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -655,7 +655,7 @@ func generateRedisStatefulSet(rf *redisfailoverv1.RedisFailover, labels map[stri
 			ServiceName: name,
 			Replicas:    &rf.Spec.Redis.Replicas,
 			UpdateStrategy: appsv1.StatefulSetUpdateStrategy{
-				Type: appsv1.OnDeleteStatefulSetStrategyType,
+				Type: appsv1.RollingUpdateStatefulSetStrategyType,
 			},
 			PodManagementPolicy: appsv1.ParallelPodManagement,
 			Selector: &metav1.LabelSelector{


### PR DESCRIPTION
In the current implementation, the [`UpdateStrategy` is set to `OnDelete`](https://github.com/spotahome/redis-operator/blob/master/operator/redisfailover/service/generator.go#L361), meaning any changes to the pod template of a StatefulSet require a full pod deletion to apply the updates. 
However, by using the `Rolling Update` strategy, the StatefulSet controller can automatically update the pods. In this pull request, I propose leveraging this feature by updating the StatefulSet pod template with an annotation. This change will automatically trigger a pod restart, ensuring updates are applied seamlessly