### PR TITLE
[FVR-182] Restarting Pods Through Deletion 

### DIFF
--- a/mocks/service/k8s/Services.go
+++ b/mocks/service/k8s/Services.go
@@ -393,6 +393,20 @@ func (_m *Services) DeleteStatefulSet(namespace string, name string) error {
 	return r0
 }
 
+// DeleteStatefulSetPods provides a mock function with given fields: namespace, name
+func (_m *Services) DeleteStatefulSetPods(namespace string, name string) error {
+	ret := _m.Called(namespace, name)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(string, string) error); ok {
+		r0 = rf(namespace, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // GetClusterRole provides a mock function with given fields: name
 func (_m *Services) GetClusterRole(name string) (*rbacv1.ClusterRole, error) {
 	ret := _m.Called(name)

--- a/service/k8s/statefulset_test.go
+++ b/service/k8s/statefulset_test.go
@@ -130,6 +130,11 @@ func TestStatefulSetServiceGetCreateOrUpdate(t *testing.T) {
 					ResourceVersion: "10",
 				},
 				Spec: appsv1.StatefulSetSpec{
+					Selector: &metav1.LabelSelector{
+						MatchLabels: map[string]string{
+							"sts": "sts",
+						},
+					},
 					VolumeClaimTemplates: []v1.PersistentVolumeClaim{
 						{
 							Spec: v1.PersistentVolumeClaimSpec{


### PR DESCRIPTION
An alternative approach to restarting StatefulSet-related pods involves removing the pods and letting the StatefulSet controller automatically recreate them. This differs from the previous implementation made in https://github.com/powerhome/redis-operator/pull/53.