### PR TITLE
[FVR-182] Restarting Pods Through STS Deletion

### DIFF
--- a/service/k8s/statefulset.go
+++ b/service/k8s/statefulset.go
@@ -162,6 +162,8 @@ func (s *StatefulSetService) CreateOrUpdateStatefulSet(namespace string, statefu
 				storedStatefulSet.Annotations = annotations
 				if realUpdate {
 					s.logger.WithField("namespace", namespace).WithField("statefulSet", statefulSet.Name).Infof("resize statefulset pvcs from %d to %d Success", storedCapacity, stateCapacity)
+					s.logger.WithField("namespace", namespace).WithField("statefulSet", statefulSet.Name).Infof("removing sts in order to recreate pods and mount volume")
+					return s.DeleteStatefulSet(namespace, statefulSet.Name)
 				} else {
 					s.logger.WithField("namespace", namespace).WithField("pvc", rfName).Warningf("set annotations,resize nothing")
 				}

--- a/service/k8s/statefulset.go
+++ b/service/k8s/statefulset.go
@@ -162,7 +162,7 @@ func (s *StatefulSetService) CreateOrUpdateStatefulSet(namespace string, statefu
 				storedStatefulSet.Annotations = annotations
 				if realUpdate {
 					s.logger.WithField("namespace", namespace).WithField("statefulSet", statefulSet.Name).Infof("resize statefulset pvcs from %d to %d Success", storedCapacity, stateCapacity)
-					s.logger.WithField("namespace", namespace).WithField("statefulSet", statefulSet.Name).Infof("removing sts in order to recreate pods and mount volume")
+					s.logger.WithField("namespace", namespace).WithField("statefulSet", statefulSet.Name).Infof("removing statefulset to mount resized pvcs")
 					return s.DeleteStatefulSet(namespace, statefulSet.Name)
 				} else {
 					s.logger.WithField("namespace", namespace).WithField("pvc", rfName).Warningf("set annotations,resize nothing")

--- a/service/k8s/statefulset_test.go
+++ b/service/k8s/statefulset_test.go
@@ -20,10 +20,13 @@ import (
 	"github.com/spotahome/redis-operator/log"
 	"github.com/spotahome/redis-operator/metrics"
 	"github.com/spotahome/redis-operator/service/k8s"
+
+	corev1 "k8s.io/api/core/v1"
 )
 
 var (
-	statefulSetsGroup = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
+	statefulSetsGroup          = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "statefulsets"}
+	persistentVolumeClaimGroup = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "persistentvolumeclaims"}
 )
 
 func newStatefulSetUpdateAction(ns string, statefulSet *appsv1.StatefulSet) kubetesting.UpdateActionImpl {
@@ -36,6 +39,19 @@ func newStatefulSetGetAction(ns, name string) kubetesting.GetActionImpl {
 
 func newStatefulSetCreateAction(ns string, statefulSet *appsv1.StatefulSet) kubetesting.CreateActionImpl {
 	return kubetesting.NewCreateAction(statefulSetsGroup, ns, statefulSet)
+}
+
+func newStatefulSetDeleteAction(ns string, name string) kubetesting.DeleteActionImpl {
+	propagation := metav1.DeletePropagationForeground
+	return kubetesting.NewDeleteActionWithOptions(statefulSetsGroup, ns, name, metav1.DeleteOptions{PropagationPolicy: &propagation})
+}
+
+func newPVCUpdateAction(pvc *corev1.PersistentVolumeClaim) kubetesting.UpdateActionImpl {
+	return kubetesting.NewUpdateAction(persistentVolumeClaimGroup, "", pvc)
+}
+
+func newPVCListAction(opts metav1.ListOptions) kubetesting.ListActionImpl {
+	return kubetesting.NewListAction(persistentVolumeClaimGroup, schema.GroupVersionKind{Group: "", Version: "v1", Kind: "PersistentVolumeClaim"}, "", opts)
 }
 
 func TestStatefulSetServiceGetCreateOrUpdate(t *testing.T) {
@@ -195,6 +211,15 @@ func TestStatefulSetServiceGetCreateOrUpdate(t *testing.T) {
 				},
 			}
 			// Mock.
+			opts := metav1.ListOptions{
+				LabelSelector: "app.kubernetes.io/component=redis,app.kubernetes.io/name=teststatefulSet1,app.kubernetes.io/part-of=redis-failover",
+			}
+			expActions := []kubetesting.Action{
+				newStatefulSetGetAction(testns, beforeSts.ObjectMeta.Name),
+				newPVCListAction(opts),
+				newPVCUpdateAction(&pvcList.Items[0]),
+				newStatefulSetDeleteAction(testns, afterSts.ObjectMeta.Name),
+			}
 			mcli := &kubernetes.Clientset{}
 			mcli.AddReactor("get", "statefulsets", func(action kubetesting.Action) (bool, runtime.Object, error) {
 				return true, beforeSts, nil
@@ -207,17 +232,36 @@ func TestStatefulSetServiceGetCreateOrUpdate(t *testing.T) {
 				pvcList.Items[0] = *action.(kubetesting.UpdateActionImpl).Object.(*v1.PersistentVolumeClaim)
 				return true, action.(kubetesting.UpdateActionImpl).Object, nil
 			})
+
+			mcli.AddReactor("delete", "statefulsets", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
+				return true, nil, nil
+			})
+
 			service := k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy)
 			err := service.CreateOrUpdateStatefulSet(testns, afterSts)
 			assert.NoError(err)
 			assert.Equal(pvcList.Items[0].Spec.Resources, pvcList.Items[1].Spec.Resources)
+			assert.Equal(expActions, mcli.Actions())
 			// should not call update
+
+			mcli = &kubernetes.Clientset{}
+			mcli.AddReactor("get", "statefulsets", func(action kubetesting.Action) (bool, runtime.Object, error) {
+				return true, afterSts, nil
+			})
+
+			expActions = []kubetesting.Action{
+				newStatefulSetGetAction(testns, beforeSts.ObjectMeta.Name),
+				newPVCListAction(opts),
+				newStatefulSetUpdateAction(testns, afterSts),
+			}
+
 			mcli.AddReactor("update", "persistentvolumeclaims", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
 				panic("shouldn't call update")
 			})
 			service = k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy)
 			err = service.CreateOrUpdateStatefulSet(testns, afterSts)
 			assert.NoError(err)
+			assert.Equal(expActions, mcli.Actions())
 		})
 	}
 }

--- a/service/k8s/statefulset_test.go
+++ b/service/k8s/statefulset_test.go
@@ -233,10 +233,6 @@ func TestStatefulSetServiceGetCreateOrUpdate(t *testing.T) {
 				return true, action.(kubetesting.UpdateActionImpl).Object, nil
 			})
 
-			mcli.AddReactor("delete", "statefulsets", func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-				return true, nil, nil
-			})
-
 			service := k8s.NewStatefulSetService(mcli, log.Dummy, metrics.Dummy)
 			err := service.CreateOrUpdateStatefulSet(testns, afterSts)
 			assert.NoError(err)


### PR DESCRIPTION
An alternative approach to restarting StatefulSet-related pods is to delete the StatefulSet itself and allow the operator to automatically recreate it during the next reconciliation loop. This differs from the previous implementation made in https://github.com/powerhome/redis-operator/pull/54