### PR TITLE
Prevent connections to replica on replica restart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
+### Changed
+
+- **BREAKING** [HAProxy: avoid sending traffic to replicas on failover](). RedisFailovers using `haproxy:` must now use a HAProxy image of v3.1.0 or greater. The operator now uses HAProxy v3.1.0 by default.
+
 ## [v3.1.0] - 2024-09-05
 
 - [Automatically recreate StatefulSet after volume expansion](https://github.com/powerhome/redis-operator/pull/55)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ### Changed
 
-- **BREAKING** [HAProxy: avoid sending traffic to replicas on failover](). RedisFailovers using `haproxy:` must now use a HAProxy image of v3.1.0 or greater. The operator now uses HAProxy v3.1.0 by default.
+- **BREAKING** [HAProxy: avoid sending traffic to replicas on failover](https://github.com/powerhome/redis-operator/pull/57/). RedisFailovers using `haproxy:` must now use a HAProxy image of v3.1.0 or greater. The operator now uses HAProxy v3.1.0 by default.
 
 ## [v3.1.0] - 2024-09-05
 

--- a/api/redisfailover/v1/defaults.go
+++ b/api/redisfailover/v1/defaults.go
@@ -6,7 +6,7 @@ const (
 	defaultSentinelExporterImage = "leominov/redis_sentinel_exporter:1.7.1"
 	defaultExporterImage         = "quay.io/oliver006/redis_exporter:v1.57.0"
 	defaultImage                 = "redis:7.2.4-alpine"
-	defaultHAProxyImage          = "haproxy:2.9.6"
+	defaultHAProxyImage          = "haproxy:3.1.0"
 	defaultRedisPort             = 6379
 )
 


### PR DESCRIPTION
There is a brief period of time during a Redis replica restart when HAProxy can send writes to it; causing the following error:

```
READONLY You can't write against a read only replica.
```

This is because HAProxy (< 3.1.0) always treats newly detected backends as immediately UP - ready to serve traffic - UNTIL they failed their checks. HAProxy v3.1.0 adds the ability to configure a backend's initial state - init-state - and how/when it HAProxy determines that the backend is ready to receive traffic.

This changes the HAProxy configuration so that a new Redis node is disqualified from client receiving traffic until HAProxy determines that the node is indeed a "master" node.

This also updates the default operator's HAProxy image accordingly to receive the `init-state` HAProxy configuration option.

References:

- https://github.com/haproxy/haproxy/issues/51
- https://github.com/haproxy/haproxy/commit/50322dff81f3c05e67bf311ff9ef0c77c833df97
