### PR TITLE
haproxy: disconnect clients when node is demoted to replica

### DIFF
--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -177,7 +177,7 @@ backend redis-master
   option tcp-check
   tcp-check send info\ replication\r\n
   tcp-check expect string role:master
-  server-template redis %d _redis._tcp.%s.%s.svc.cluster.local:%d check inter 1s resolvers k8s init-addr none init-state down
+  server-template redis %d _redis._tcp.%s.%s.svc.cluster.local:%d check inter 1s resolvers k8s init-addr none init-state down on-marked-down shutdown-sessions
 `, port, rf.Spec.Redis.Replicas, redisName, namespace, port)
 
 	if rf.Spec.Haproxy.CustomConfig != "" {


### PR DESCRIPTION
Some clients do not gracefully handle when a failover occurs; they keep the established connection open. When the redis node comes back up as a replica, the client recieves an error indicating that they cannot write against the replica:

```
READONLY You can't write against a read only replica
```

This closes client connections to a redis node when haproxy detects that it is in a "down" state. The idea is that the clients will recognize they need to reestablish a connection. 

References:
- https://docs.haproxy.org/3.1/configuration.html#5.2-on-marked-down