### PR TITLE
Fix integration test runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,7 +41,7 @@ jobs:
 
   integration-test:
     name: Integration test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs:
       - check
       - unit-test


### PR DESCRIPTION
Related to: 
- https://github.com/medyagh/setup-minikube/issues/565
- https://github.com/powerhome/redis-operator/actions/runs/12774059053/job/35608701152#step:5:78

```
 Preparing to unpack .../socat_1.8.0.0-4build3_amd64.deb ...
Unpacking socat (1.8.0.0-4build3) ...
Setting up socat (1.8.0.0-4build3) ...
Processing triggers for man-db (2.12.0-4build2) ...

Running kernel seems to be up-to-date.

No services need to be restarted.

No containers need to be restarted.

No user sessions are running outdated binaries.

No VM guests are running outdated hypervisor (qemu) binaries on this host.
/usr/bin/lsb_release --short --codename
noble
Error: Unexpected HTTP response: 404
```