### PR TITLE
Forever People was merged into GOG

### DIFF
--- a/portal.yml
+++ b/portal.yml
@@ -13,6 +13,6 @@ metadata:
     backstage.io/techdocs-ref: dir:.
     github.com/project-slug: powerhome/redis-operator
 spec:
-  owner: forever-people
+  owner: guardians-of-the-galaxy
   domain: technology-foundations-and-tools
   lifecycle: production


### PR DESCRIPTION
This is to change the owner of this operator from the now defunct Forever People team to Guardians of the Galaxy.