### PR TITLE
Fix buildx and bake action compatibility issues

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build
-        uses: docker/bake-action@v3
+        uses: docker/bake-action@v6.8.0
         with:
           files: |
             ./docker-bake.hcl

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -115,7 +115,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build
-        uses: docker/bake-action@v6.8.0
+        uses: docker/bake-action@v5
         with:
           files: |
             ./docker-bake.hcl


### PR DESCRIPTION
Fix buildx and bake action compatibility issues in the `ci` GitHub workflow.

- https://github.com/powerhome/redis-operator/actions/runs/12935287363/job/36078911603

```
docker/bake-action < v5 is not compatible with buildx >= 0.20.0, please update your workflow to latest docker/bake-action or use an older buildx version.
```