### PR TITLE
Allow diff ports on boostrapNode and redis pods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
+- [Allow different ports on BootstrapNode and RF]()
+
 ## [v4.1.0]  - 2025-01-16
 
 ### Changed

--- a/mocks/service/redis/Client.go
+++ b/mocks/service/redis/Client.go
@@ -188,13 +188,13 @@ func (_m *Client) MakeSlaveOf(ip string, masterIP string, password string) error
 	return r0
 }
 
-// MakeSlaveOfWithPort provides a mock function with given fields: ip, masterIP, masterPort, password
-func (_m *Client) MakeSlaveOfWithPort(ip string, masterIP string, masterPort string, password string) error {
-	ret := _m.Called(ip, masterIP, masterPort, password)
+// MakeSlaveOfWithPort provides a mock function with given fields: ip, port, masterIP, masterPort, password
+func (_m *Client) MakeSlaveOfWithPort(ip string, port string, masterIP string, masterPort string, password string) error {
+	ret := _m.Called(ip, port, masterIP, masterPort, password)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, string, string, string) error); ok {
-		r0 = rf(ip, masterIP, masterPort, password)
+	if rf, ok := ret.Get(0).(func(string, string, string, string, string) error); ok {
+		r0 = rf(ip, port, masterIP, masterPort, password)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/operator/redisfailover/service/heal.go
+++ b/operator/redisfailover/service/heal.go
@@ -141,7 +141,7 @@ func (r *RedisFailoverHealer) SetOldestAsMaster(rf *redisfailoverv1.RedisFailove
 			newMasterIP = pod.Status.PodIP
 		} else {
 			r.logger.Infof("Making pod %s slave of %s", pod.Name, newMasterIP)
-			if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, newMasterIP, port, password); err != nil {
+			if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, port, newMasterIP, port, password); err != nil {
 				r.logger.WithField("redisfailover", rf.ObjectMeta.Name).WithField("namespace", rf.ObjectMeta.Namespace).Errorf("Make slave failed, slave pod ip: %s, master ip: %s, error: %v", pod.Status.PodIP, newMasterIP, err)
 			}
 
@@ -182,7 +182,7 @@ func (r *RedisFailoverHealer) SetMasterOnAll(masterIP string, rf *redisfailoverv
 				continue
 			}
 			r.logger.WithField("redisfailover", rf.ObjectMeta.Name).WithField("namespace", rf.ObjectMeta.Namespace).Infof("Making pod %s slave of %s", pod.Name, masterIP)
-			if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, masterIP, port, password); err != nil {
+			if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, port, masterIP, port, password); err != nil {
 				r.logger.WithField("redisfailover", rf.ObjectMeta.Name).WithField("namespace", rf.ObjectMeta.Namespace).Errorf("Make slave failed, slave ip: %s, master ip: %s, error: %v", pod.Status.PodIP, masterIP, err)
 				return err
 			}
@@ -209,9 +209,10 @@ func (r *RedisFailoverHealer) SetExternalMasterOnAll(masterIP, masterPort string
 		return err
 	}
 
+	port := rf.Spec.Redis.Port.ToString()
 	for _, pod := range ssp.Items {
 		r.logger.WithField("redisfailover", rf.ObjectMeta.Name).WithField("namespace", rf.ObjectMeta.Namespace).Infof("Making pod %s slave of %s:%s", pod.Name, masterIP, masterPort)
-		if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, masterIP, masterPort, password); err != nil {
+		if err := r.redisClient.MakeSlaveOfWithPort(pod.Status.PodIP, port, masterIP, masterPort, password); err != nil {
 			return err
 		}
 

--- a/operator/redisfailover/service/heal_test.go
+++ b/operator/redisfailover/service/heal_test.go
@@ -124,7 +124,7 @@ func TestSetOldestAsMasterMultiplePodsMakeSlaveOfError(t *testing.T) {
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "0.0.0.0", "0", "").Once().Return(nil)
-	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(errors.New(""))
+	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "0.0.0.0", "0", "").Once().Return(errors.New(""))
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -157,7 +157,7 @@ func TestSetOldestAsMasterMultiplePods(t *testing.T) {
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "0.0.0.0", "0", "").Once().Return(nil)
-	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "0.0.0.0", "0", "").Once().Return(nil)
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -200,7 +200,7 @@ func TestSetOldestAsMasterOrdering(t *testing.T) {
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("MakeMaster", "1.1.1.1", "0", "").Once().Return(nil)
-	mr.On("MakeSlaveOfWithPort", "0.0.0.0", "1.1.1.1", "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", "0.0.0.0", "0", "1.1.1.1", "0", "").Once().Return(nil)
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -264,7 +264,7 @@ func TestSetMasterOnAllMakeSlaveOfError(t *testing.T) {
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("IsMaster", "0.0.0.0", "0", "").Return(true, nil)
-	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(errors.New(""))
+	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "0.0.0.0", "0", "").Once().Return(errors.New(""))
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -297,7 +297,7 @@ func TestSetMasterOnAll(t *testing.T) {
 	ms.On("UpdatePodLabels", namespace, mock.AnythingOfType("string"), mock.Anything).Return(nil)
 	mr := &mRedisService.Client{}
 	mr.On("IsMaster", "0.0.0.0", "0", "").Return(true, nil)
-	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0.0.0.0", "0", "").Once().Return(nil)
+	mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "0.0.0.0", "0", "").Once().Return(nil)
 
 	healer := rfservice.NewRedisFailoverHealer(ms, mr, log.DummyLogger{})
 
@@ -355,12 +355,12 @@ func TestSetExternalMasterOnAll(t *testing.T) {
 
 			mr := &mRedisService.Client{}
 			if !expectError {
-				mr.On("MakeSlaveOfWithPort", "0.0.0.0", "5.5.5.5", "6379", "").Once().Return(nil)
+				mr.On("MakeSlaveOfWithPort", "0.0.0.0", "0", "5.5.5.5", "6379", "").Once().Return(nil)
 				if test.errorOnMakeSlaveOf {
 					expectError = true
-					mr.On("MakeSlaveOfWithPort", "1.1.1.1", "5.5.5.5", "6379", "").Once().Return(errors.New(""))
+					mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "5.5.5.5", "6379", "").Once().Return(errors.New(""))
 				} else {
-					mr.On("MakeSlaveOfWithPort", "1.1.1.1", "5.5.5.5", "6379", "").Once().Return(nil)
+					mr.On("MakeSlaveOfWithPort", "1.1.1.1", "0", "5.5.5.5", "6379", "").Once().Return(nil)
 				}
 			}
 

--- a/service/redis/client.go
+++ b/service/redis/client.go
@@ -27,7 +27,7 @@ type Client interface {
 	MakeMaster(ip, port, password string) error
 	ResetReplicaConnections(ip, port, password string) error
 	MakeSlaveOf(ip, masterIP, password string) error
-	MakeSlaveOfWithPort(ip, masterIP, masterPort, password string) error
+	MakeSlaveOfWithPort(ip, port, masterIP, masterPort, password string) error
 	GetSentinelMonitor(ip string, port string) (string, string, error)
 	SetCustomSentinelConfig(ip string, port string, configs []string) error
 	SetCustomRedisConfig(ip string, port string, configs []string, password string) error
@@ -313,12 +313,12 @@ func (c client) ResetReplicaConnections(ip string, port string, password string)
 }
 
 func (c *client) MakeSlaveOf(ip, masterIP, password string) error {
-	return c.MakeSlaveOfWithPort(ip, masterIP, redisPort, password)
+	return c.MakeSlaveOfWithPort(ip, redisPort, masterIP, redisPort, password)
 }
 
-func (c *client) MakeSlaveOfWithPort(ip, masterIP, masterPort, password string) error {
+func (c *client) MakeSlaveOfWithPort(ip, port, masterIP, masterPort, password string) error {
 	options := &rediscli.Options{
-		Addr:     net.JoinHostPort(ip, masterPort), // this is IP and Port for the RedisFailover redis
+		Addr:     net.JoinHostPort(ip, port), // this is IP and Port for the RedisFailover redis
 		Password: password,
 		DB:       0,
 	}


### PR DESCRIPTION
Boostrapping fails if the bootstrapNode and RF's redis port are different. 

The operator uses the bootstrapNode's port when trying to run `SLAVEOF` on the RF pods and fails to connect:

Example RF config:
```yaml
  bootstrapNode:
    enabled: true
    host: redis-primary-host.io
    port: "36379"
...
  redis:
    port: 6679
...
```

Example failure logs:
```
time="2025-06-05T19:08:29Z" level=info msg="Making pod rfr-redis-0 slave of redis-primary-host.io:36379" namespace=redis-test redisfailover=redis service=redis.healer src="checker.go:261"
time="2025-06-05T19:08:29Z" level=error msg="error on object processing: dial tcp 10.244.2.7:36379: connect: connection refused" controller-id=redisfailover object-key=redis-test/redis operator=redisfailover service=kooper.controller src="controller.go:282"
```

This alters `MakeSlaveOfWithPort` to allow the caller to speficy different ports for the primary and replica redis instances. Additonally, `SetExternalMasterOnAll` is alertered to pass along the boostrapNode's port as well as the RF resources's port - which _can_ be different. 