### PR TITLE
Haproxy: Fix service labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ### Added
 
+- [Haproxy: add additional service labels](https://github.com/powerhome/redis-operator/pull/66)
 - [Haproxy: optionally expose prometheus metrics](https://github.com/powerhome/redis-operator/pull/65)
 
 ### Fixed

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -55,9 +55,15 @@ func generateHAProxyRedisMasterDeployment(rf *redisfailoverv1.RedisFailover, lab
 	name := GetHaproxyMasterName(rf)
 
 	namespace := rf.Namespace
-
-	labels = util.MergeLabels(labels, generateSelectorLabels("haproxy", rf.Name), generateRedisMasterRoleLabel())
-	selectorLabels := util.MergeLabels(labels, generateComponentLabel("haproxy"))
+	labels = util.MergeLabels(
+		labels,
+		generateSelectorLabels("haproxy", rf.Name),
+		generateRedisMasterRoleLabel(),
+	)
+	selectorLabels := util.MergeLabels(
+		labels,
+		generateComponentLabel("haproxy"),
+	)
 
 	volumeMounts := []corev1.VolumeMount{
 		{
@@ -261,10 +267,16 @@ func generateHAProxyRedisMasterService(rf *redisfailoverv1.RedisFailover, labels
 	}
 	namespace := rf.Namespace
 	redisTargetPort := intstr.FromInt(int(rf.Spec.Redis.Port))
-	selectorLabels := util.MergeLabels(labels, generateSelectorLabels("haproxy", rf.Name), generateRedisMasterRoleLabel())
 
-	selectorLabels = util.MergeLabels(selectorLabels, generateComponentLabel("haproxy"))
-	selectorLabels = util.MergeLabels(labels, selectorLabels)
+	labels = util.MergeLabels(
+		labels,
+		generateSelectorLabels("haproxy", rf.Name),
+		generateRedisMasterRoleLabel(),
+	)
+	selectorLabels := util.MergeLabels(
+		labels,
+		generateComponentLabel("haproxy"),
+	)
 
 	ports := []corev1.ServicePort{
 		{

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -1314,6 +1314,12 @@ func TestHaproxyService(t *testing.T) {
 			rfRedisPort: defaultRedisPort,
 			expectedService: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "haproxy",
+						"app.kubernetes.io/name":      "test",
+						"app.kubernetes.io/part-of":   "redis-failover",
+						"redisfailovers-role":         "master",
+					},
 					Name:      haproxyName,
 					Namespace: namespace,
 					OwnerReferences: []metav1.OwnerReference{
@@ -1352,6 +1358,12 @@ func TestHaproxyService(t *testing.T) {
 			},
 			expectedService: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "haproxy",
+						"app.kubernetes.io/name":      "test",
+						"app.kubernetes.io/part-of":   "redis-failover",
+						"redisfailovers-role":         "master",
+					},
 					Name:      haproxyName,
 					Namespace: namespace,
 					OwnerReferences: []metav1.OwnerReference{
@@ -1392,6 +1404,12 @@ func TestHaproxyService(t *testing.T) {
 			},
 			expectedService: corev1.Service{
 				ObjectMeta: metav1.ObjectMeta{
+					Labels: map[string]string{
+						"app.kubernetes.io/component": "haproxy",
+						"app.kubernetes.io/name":      "test",
+						"app.kubernetes.io/part-of":   "redis-failover",
+						"redisfailovers-role":         "master",
+					},
 					Name:      haproxyName,
 					Namespace: namespace,
 					OwnerReferences: []metav1.OwnerReference{


### PR DESCRIPTION
Bring the haproxy service labels into a similar shape as the redis
service labels. Makes it easier to select just the haproxy service by
its labels.

Current Redis "Master" Service labels:
``` yaml
metadata:
  labels:
    app.kubernetes.io/component: redis
    app.kubernetes.io/managed-by: redis-operator
    app.kubernetes.io/name: redis
    app.kubernetes.io/part-of: redis-failover
    redisfailovers-role: master
    redisfailovers.databases.spotahome.com/name: redis
```

Additions to the Haproxy Service labels:
``` diff
metadata:
  labels:
+   app.kubernetes.io/component: haproxy
    app.kubernetes.io/managed-by: redis-operator
+   app.kubernetes.io/name: redis
+   app.kubernetes.io/part-of: redis-failover
+   redisfailovers-role: master
    redisfailovers.databases.spotahome.com/name: redis
```