### PR TITLE
Fix CHANGELOG.md version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
-## [v4.1.0] - 2025-06-20
+## [v4.2.0] - 2025-06-20
 
 ### Added
 


### PR DESCRIPTION
I messed up the changelog version number in https://github.com/powerhome/redis-operator/pull/67. 