### PR TITLE
Haproxy: bootstrap puts haproxy into maint mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
+### Changed
+
+- [Haproxy: Haproxy: bootstrap puts haproxy into maint mode]()
+
 ## [v4.2.0] - 2025-06-20
 
 ### Added

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -38,3 +38,7 @@ const (
 	redisRoleLabelMaster = "master"
 	redisRoleLabelSlave  = "slave"
 )
+
+const (
+	haproxyConfigChecksumAnnotationKey = "checksum/haproxy-cfg"
+)

--- a/operator/redisfailover/service/generator.go
+++ b/operator/redisfailover/service/generator.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"strconv"
 	"strings"
@@ -142,26 +144,40 @@ func generateHAProxyRedisMasterDeployment(rf *redisfailoverv1.RedisFailover, lab
 
 func generateHAProxyRedisMasterConfigmap(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.ConfigMap {
 	name := GetHaproxyMasterName(rf)
-	redisName := rf.GenerateName("redis")
-
-	namespace := rf.Namespace
 
 	labels = util.MergeLabels(labels, generateSelectorLabels("haproxy", rf.Name), generateRedisMasterRoleLabel())
 
-	port := rf.Spec.Redis.Port
+	haproxyCfg := GenerateHaproxyConfig(
+		rf,
+		rf.Bootstrapping(),
+	)
 
-	prometheusFrontend := ""
-	if rf.Spec.Haproxy.Exporter != nil && rf.Spec.Haproxy.Exporter.Enabled {
-		prometheusFrontend = fmt.Sprintf(`
-frontend prometheus
-  bind :%d
-  mode http
-  http-request use-service prometheus-exporter
-  no log
-`, rf.Spec.Haproxy.Exporter.Port.ToInt32())
+	hash := sha256.Sum256([]byte(haproxyCfg))
+	digest := hex.EncodeToString(hash[:])
+
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: rf.Namespace,
+			Labels:    labels,
+			Annotations: map[string]string{
+				haproxyConfigChecksumAnnotationKey: digest,
+			},
+			OwnerReferences: ownerRefs,
+		},
+		Data: map[string]string{
+			"haproxy.cfg": haproxyCfg,
+		},
+	}
+}
+
+func GenerateHaproxyConfig(rf *redisfailoverv1.RedisFailover, bootstrapping bool) string {
+	if rf.Spec.Haproxy.CustomConfig != "" {
+		return rf.Spec.Haproxy.CustomConfig
 	}
 
-	haproxyCfg := fmt.Sprintf(`
+	var haproxyCfgBuilder strings.Builder
+	haproxyCfgBuilder.WriteString(`
 global
   daemon
   maxconn 5000
@@ -172,8 +188,6 @@ defaults
   timeout client 50000ms
   timeout server 50000ms
   timeout check 5000ms
-
-%s
 
 frontend http
   bind :8080
@@ -196,6 +210,22 @@ resolvers k8s
   hold valid 10s
   hold obsolete 10s
 
+`)
+
+	if rf.Spec.Haproxy.Exporter != nil && rf.Spec.Haproxy.Exporter.Enabled {
+		haproxyCfgBuilder.WriteString(fmt.Sprintf(`
+frontend prometheus
+  bind :%d
+  mode http
+  http-request use-service prometheus-exporter
+  no log
+
+`,
+			rf.Spec.Haproxy.Exporter.Port.ToInt32(),
+		))
+	}
+
+	haproxyCfgBuilder.WriteString(fmt.Sprintf(`
 frontend redis-master
   bind *:%d
   default_backend redis-master
@@ -206,24 +236,21 @@ backend redis-master
   option tcp-check
   tcp-check send info\ replication\r\n
   tcp-check expect string role:master
-  server-template redis %d _redis._tcp.%s.%s.svc.cluster.local:%d check inter 1s resolvers k8s init-addr none init-state down on-marked-down shutdown-sessions
-`, prometheusFrontend, port, rf.Spec.Redis.Replicas, redisName, namespace, port)
+  server-template redis %d _redis._tcp.%s.%s.svc.cluster.local:%d check inter 1s resolvers k8s init-addr none init-state down on-marked-down shutdown-sessions`,
+		rf.Spec.Redis.Port,
+		rf.Spec.Redis.Replicas,
+		rf.GenerateName("redis"),
+		rf.Namespace,
+		rf.Spec.Redis.Port,
+	))
 
-	if rf.Spec.Haproxy.CustomConfig != "" {
-		haproxyCfg = rf.Spec.Haproxy.CustomConfig
+	if bootstrapping {
+		haproxyCfgBuilder.WriteString(" disabled")
 	}
+	haproxyCfgBuilder.WriteString("\n")
 
-	return &corev1.ConfigMap{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            name,
-			Namespace:       namespace,
-			Labels:          labels,
-			OwnerReferences: ownerRefs,
-		},
-		Data: map[string]string{
-			"haproxy.cfg": haproxyCfg,
-		},
-	}
+	return haproxyCfgBuilder.String()
+
 }
 
 func generateRedisHeadlessService(rf *redisfailoverv1.RedisFailover, labels map[string]string, ownerRefs []metav1.OwnerReference) *corev1.Service {

--- a/operator/redisfailover/service/generator_test.go
+++ b/operator/redisfailover/service/generator_test.go
@@ -2,6 +2,7 @@ package service_test
 
 import (
 	"fmt"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1475,6 +1476,110 @@ func TestHaproxyService(t *testing.T) {
 
 			assert.Equal(test.expectedService, generatedService)
 			assert.NoError(err)
+		})
+	}
+}
+
+func TestGenerateHaproxyConfig(t *testing.T) {
+	tests := []struct {
+		name         string
+		rf           *redisfailoverv1.RedisFailover
+		bootstrap    bool
+		mustMatch    []string
+		mustNotMatch []string
+	}{
+		{
+			name: "returns CustomConfig when provided",
+			rf: &redisfailoverv1.RedisFailover{
+				Spec: redisfailoverv1.RedisFailoverSpec{
+					Haproxy: &redisfailoverv1.HaproxySettings{
+						CustomConfig: "custom config here",
+					},
+				},
+			},
+			mustMatch: []string{"custom config here"},
+		},
+		{
+			name: "includes exporter block when enabled",
+			rf: &redisfailoverv1.RedisFailover{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns"},
+				Spec: redisfailoverv1.RedisFailoverSpec{
+					Redis: redisfailoverv1.RedisSettings{
+						Port:     6379,
+						Replicas: 3,
+					},
+					Haproxy: &redisfailoverv1.HaproxySettings{
+						Exporter: &redisfailoverv1.HaproxyExporterSettings{
+							Enabled: true,
+							Port:    9101,
+						},
+					},
+				},
+			},
+			mustMatch: []string{
+				"frontend prometheus",
+				"bind :9101",
+			},
+		},
+		{
+			name: "includes an active redis-master block when not bootstrapping",
+			rf: &redisfailoverv1.RedisFailover{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "expected-name"},
+				Spec: redisfailoverv1.RedisFailoverSpec{
+					Redis: redisfailoverv1.RedisSettings{
+						Port:     6379,
+						Replicas: 3,
+					},
+					Haproxy: &redisfailoverv1.HaproxySettings{},
+				},
+			},
+			mustMatch: []string{
+				`frontend redis-master`,
+				`server-template redis 3 _redis\._tcp\.redis-expected-name\.test-ns\.svc\.cluster\.local:6379.*\n`,
+			},
+			mustNotMatch: []string{
+				`server-template.*disabled\n$`,
+			},
+		},
+		{
+			name: "includes an administratively disabled redis-master block when bootstrapping",
+			rf: &redisfailoverv1.RedisFailover{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "test-ns", Name: "expected-name"},
+				Spec: redisfailoverv1.RedisFailoverSpec{
+					Redis: redisfailoverv1.RedisSettings{
+						Port:     6379,
+						Replicas: 3,
+					},
+					Haproxy: &redisfailoverv1.HaproxySettings{},
+				},
+			},
+			bootstrap: true,
+			mustMatch: []string{
+				`frontend redis-master`,
+				`server-template redis 3 _redis\._tcp\.redis-expected-name\.test-ns\.svc\.cluster\.local:6379.*disabled\n$`,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rf := *test.rf // shallow copy
+
+			cfg := rfservice.GenerateHaproxyConfig(&rf, test.bootstrap)
+
+			for _, pattern := range test.mustMatch {
+				re := regexp.MustCompile(pattern)
+				if !re.MatchString(cfg) {
+					t.Errorf("expected config to match pattern %q\nConfig:\n%s", pattern, cfg)
+				}
+			}
+
+			for _, pattern := range test.mustNotMatch {
+				re := regexp.MustCompile(pattern)
+				if re.MatchString(cfg) {
+					t.Errorf("expected config NOT to match pattern %q\nConfig:\n%s", pattern, cfg)
+				}
+			}
 		})
 	}
 }


### PR DESCRIPTION
When bootstrapping, the haproxy resources are still deployed. Set the redis-master backend into maintenance mode to indicate that client connections are expected to fail.
