### PR TITLE
Haproxy: remove haproxy master resources when bootstrapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
+### Changed
+
+- [Haproxy: remove haproxy master resources when bootstrapping](https://github.com/powerhome/redis-operator/pull/70)
+
 ## [v4.2.0] - 2025-06-20
 
 ### Added

--- a/api/redisfailover/v1/bootstrapping.go
+++ b/api/redisfailover/v1/bootstrapping.go
@@ -10,3 +10,9 @@ func (r *RedisFailover) SentinelsAllowed() bool {
 	bootstrapping := r.Bootstrapping()
 	return !bootstrapping || (bootstrapping && r.Spec.BootstrapNode.AllowSentinels)
 }
+
+// HaproxyAllowed returns true if haproxy is allowed to run
+func (r *RedisFailover) HaproxyAllowed() bool {
+	bootstrapping := r.Bootstrapping()
+	return !bootstrapping
+}

--- a/api/redisfailover/v1/bootstrapping_test.go
+++ b/api/redisfailover/v1/bootstrapping_test.go
@@ -86,3 +86,32 @@ func TestSentinelsAllowed(t *testing.T) {
 		})
 	}
 }
+
+func TestHaproxyAllowed(t *testing.T) {
+	tests := []struct {
+		name              string
+		expectation       bool
+		bootstrapSettings *BootstrapSettings
+	}{
+		{
+			name:        "without BootstrapSettings",
+			expectation: true,
+		},
+		{
+			name:        "with BootstrapSettings",
+			expectation: false,
+			bootstrapSettings: &BootstrapSettings{
+				Host:    "127.0.0.1",
+				Port:    "6379",
+				Enabled: true,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			rf := generateRedisFailover("test", test.bootstrapSettings)
+			assert.Equal(t, test.expectation, rf.HaproxyAllowed())
+		})
+	}
+}

--- a/mocks/operator/redisfailover/service/RedisFailoverClient.go
+++ b/mocks/operator/redisfailover/service/RedisFailoverClient.go
@@ -14,6 +14,20 @@ type RedisFailoverClient struct {
 	mock.Mock
 }
 
+// DestroyHaproxyMasterResources provides a mock function with given fields: rFailover
+func (_m *RedisFailoverClient) DestroyHaproxyMasterResources(rFailover *v1.RedisFailover) error {
+	ret := _m.Called(rFailover)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(*v1.RedisFailover) error); ok {
+		r0 = rf(rFailover)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // DestroyOrphanedRedisSlaveHaProxy provides a mock function with given fields: rFailover
 func (_m *RedisFailoverClient) DestroyOrphanedRedisSlaveHaProxy(rFailover *v1.RedisFailover) error {
 	ret := _m.Called(rFailover)

--- a/operator/redisfailover/ensurer.go
+++ b/operator/redisfailover/ensurer.go
@@ -30,24 +30,31 @@ func (w *RedisFailoverHandler) Ensure(rf *redisfailoverv1.RedisFailover, labels 
 	}
 
 	if rf.Spec.Haproxy != nil {
-		if err := w.rfService.EnsureHAProxyRedisMasterService(rf, labels, or); err != nil {
-			return err
-		}
+		haproxyAllowed := rf.HaproxyAllowed()
+		if haproxyAllowed {
+			if err := w.rfService.EnsureHAProxyRedisMasterService(rf, labels, or); err != nil {
+				return err
+			}
 
-		if err := w.rfService.EnsureRedisHeadlessService(rf, labels, or); err != nil {
-			return err
-		}
+			if err := w.rfService.EnsureRedisHeadlessService(rf, labels, or); err != nil {
+				return err
+			}
 
-		if err := w.rfService.EnsureHAProxyRedisMasterConfigmap(rf, labels, or); err != nil {
-			return err
-		}
+			if err := w.rfService.EnsureHAProxyRedisMasterConfigmap(rf, labels, or); err != nil {
+				return err
+			}
 
-		if err := w.rfService.EnsureHAProxyRedisMasterDeployment(rf, labels, or); err != nil {
-			return err
-		}
+			if err := w.rfService.EnsureHAProxyRedisMasterDeployment(rf, labels, or); err != nil {
+				return err
+			}
 
-		if err := w.rfService.DestroyOrphanedRedisSlaveHaProxy(rf); err != nil {
-			return err
+			if err := w.rfService.DestroyOrphanedRedisSlaveHaProxy(rf); err != nil {
+				return err
+			}
+		} else {
+			if err := w.rfService.DestroyHaproxyMasterResources(rf); err != nil {
+				return err
+			}
 		}
 	}
 

--- a/operator/redisfailover/ensurer_test.go
+++ b/operator/redisfailover/ensurer_test.go
@@ -97,6 +97,13 @@ func TestEnsure(t *testing.T) {
 			bootstrappingAllowSentinels: false,
 			haproxy:                     true,
 		},
+		{
+			name:                        "bootstrapping with haproxy enabled",
+			exporter:                    false,
+			bootstrapping:               true,
+			bootstrappingAllowSentinels: false,
+			haproxy:                     true,
+		},
 	}
 
 	for _, test := range tests {
@@ -134,12 +141,16 @@ func TestEnsure(t *testing.T) {
 			}
 
 			if test.haproxy {
-				mrfs.On("EnsureHAProxyRedisMasterService", rf, mock.Anything, mock.Anything).Once().Return(nil)
-				mrfs.On("EnsureRedisHeadlessService", rf, mock.Anything, mock.Anything).Once().Return(nil)
-				mrfs.On("EnsureHAProxyRedisMasterConfigmap", rf, mock.Anything, mock.Anything).Once().Return(nil)
-				mrfs.On("EnsureHAProxyRedisMasterDeployment", rf, mock.Anything, mock.Anything).Once().Return(nil)
+				if !test.bootstrapping {
+					mrfs.On("EnsureHAProxyRedisMasterService", rf, mock.Anything, mock.Anything).Once().Return(nil)
+					mrfs.On("EnsureRedisHeadlessService", rf, mock.Anything, mock.Anything).Once().Return(nil)
+					mrfs.On("EnsureHAProxyRedisMasterConfigmap", rf, mock.Anything, mock.Anything).Once().Return(nil)
+					mrfs.On("EnsureHAProxyRedisMasterDeployment", rf, mock.Anything, mock.Anything).Once().Return(nil)
 
-				mrfs.On("DestroyOrphanedRedisSlaveHaProxy", rf, mock.Anything, mock.Anything).Once().Return(nil)
+					mrfs.On("DestroyOrphanedRedisSlaveHaProxy", rf, mock.Anything, mock.Anything).Once().Return(nil)
+				} else {
+					mrfs.On("DestroyHaproxyMasterResources", rf, mock.Anything, mock.Anything).Once().Return(nil)
+				}
 			}
 
 			mrfs.On("EnsureRedisMasterService", rf, mock.Anything, mock.Anything).Once().Return(nil)

--- a/operator/redisfailover/service/constants.go
+++ b/operator/redisfailover/service/constants.go
@@ -38,3 +38,7 @@ const (
 	redisRoleLabelMaster = "master"
 	redisRoleLabelSlave  = "slave"
 )
+
+const (
+	haproxyConfigChecksumAnnotationKey = "checksum/haproxy-cfg"
+)


### PR DESCRIPTION
When bootstrapping, the haproxy resources are still deployed. Remove
the redis-master haproxy service config as we expect no master to be
running during bootstrapping.