### PR TITLE
[GOG-1162] Fix Cluster Health Check to Skip HAProxy Validation in Bootstrap Mode

### DIFF
--- a/operator/redisfailover/service/check_test.go
+++ b/operator/redisfailover/service/check_test.go
@@ -1012,6 +1012,13 @@ func TestClusterRunning(t *testing.T) {
 
 	assert.False(checker.IsClusterRunning(rf))
 
+	rf.Spec.Haproxy = nil
+	ms = &mK8SService.Services{}
+	ms.On("GetDeploymentPods", namespace, rfservice.GetSentinelName(rf)).Once().Return(allRunning, nil)
+	ms.On("GetStatefulSetPods", namespace, rfservice.GetRedisName(rf)).Once().Return(allRunning, nil)
+	checker = rfservice.NewRedisFailoverChecker(ms, mr, log.DummyLogger{}, metrics.Dummy)
+
+	assert.True(checker.IsClusterRunning(rf))
 }
 
 func TestClusterRunningWithBootstrap(t *testing.T) {


### PR DESCRIPTION
Starting with version [2.4.0 of the redis-operator](https://github.com/powerhome/redis-operator/releases/tag/v4.3.0), we are removing HAProxy from the  cluster in bootstrap mode. 

However, the cluster health check still expects HAProxy to be present. 

```
if rFailover.Bootstrapping() && !rFailover.SentinelsAllowed() {
    return r.IsRedisRunning(rFailover) && r.IsHAProxyRunning(rFailover)
}
```

As a result, the health check fails, preventing the Redis custom resource from updating its status and causing the deployment to fail.

Logic now distinguishes between:

- Bootstrap mode with sentinels disabled → only Redis must be running.

- Bootstrap mode with sentinels allowed → Redis and Sentinel must be running.

- Normal mode → Redis, Sentinel, and HAProxy must all be running.