### PR TITLE
Drop support for kube <= 1.22

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,8 +48,6 @@ jobs:
     strategy:
       matrix:
         kubernetes:
-          - 1.21.14
-          - 1.22.17
           - 1.23.17
           - 1.24.16
           - 1.25.12

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
+- [Drop support for kube versions 1.22 and older](https://github.com/powerhome/redis-operator/pull/74)
+
 ## [v4.3.1] - 2025-07-16
 
 ### Fixed


### PR DESCRIPTION
In an effort to keep maintenance burden more reasonable over time,
we're officially support for kube versions 1.22 and older.