### PR TITLE
Fix operator's clusterrole kustomize template and examples

### DIFF
--- a/example/operator/all-redis-operator-resources.yaml
+++ b/example/operator/all-redis-operator-resources.yaml
@@ -57,6 +57,7 @@ rules:
     resources:
       - redisfailovers
       - redisfailovers/finalizers
+      - redisfailovers/status
     verbs:
       - "*"
   - apiGroups:
@@ -97,12 +98,19 @@ rules:
     verbs:
       - "*"
   - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list
+  - apiGroups:
       - coordination.k8s.io
     resources:
       - leases
     verbs:
       - "*"
-      
+
 ---
 apiVersion: v1
 kind: ServiceAccount

--- a/example/operator/roles.yaml
+++ b/example/operator/roles.yaml
@@ -8,6 +8,7 @@ rules:
     resources:
       - redisfailovers
       - redisfailovers/finalizers
+      - redisfailovers/status
     verbs:
       - "*"
   - apiGroups:
@@ -51,3 +52,10 @@ rules:
       - poddisruptionbudgets
     verbs:
       - "*"
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list

--- a/manifests/kustomize/components/rbac/clusterrole.yaml
+++ b/manifests/kustomize/components/rbac/clusterrole.yaml
@@ -8,6 +8,7 @@ rules:
     resources:
       - redisfailovers
       - redisfailovers/finalizers
+      - redisfailovers/status
     verbs:
       - "*"
   - apiGroups:
@@ -24,7 +25,7 @@ rules:
     - create
     - get
     - list
-    - update      
+    - update
   - apiGroups:
       - ""
     resources:
@@ -51,3 +52,10 @@ rules:
       - poddisruptionbudgets
     verbs:
       - "*"
+  - apiGroups:
+      - networking.k8s.io
+    resources:
+      - networkpolicies
+    verbs:
+      - get
+      - list


### PR DESCRIPTION
A long, long time ago we added the network policy resource[^1] and a
status field[^2] to the custom resource; the operator is meant to
manage these. However, we didn't updated the operator's clusterrole
templates to reflect the resources necessary to do this. Let's fix
that here.

[^1]: https://github.com/powerhome/redis-operator/pull/2
[^2]: https://github.com/powerhome/redis-operator/pull/7