### PR TITLE
Update Kubernetes testing matrix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -48,11 +48,10 @@ jobs:
     strategy:
       matrix:
         kubernetes:
-          - 1.23.17
           - 1.32.8
-          - 1.33.10
-          - 1.34.6
-          - 1.35.3
+          - 1.33.8
+          - 1.34.4
+          - 1.35.1
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4
@@ -60,10 +59,10 @@ jobs:
           go-version-file: go.mod
       - name: Install conntrack
         run: sudo apt-get install -y conntrack
-      - uses: medyagh/setup-minikube@v0.0.14
+      - uses: medyagh/setup-minikube@v0.0.18
         with:
           kubernetes-version: ${{ matrix.kubernetes }}
-          minikube-version: 1.31.1
+          minikube-version: 1.38.1
           driver: none
       - name: Add redisfailover CRD
         run: kubectl create -f manifests/databases.spotahome.com_redisfailovers.yaml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,12 +49,10 @@ jobs:
       matrix:
         kubernetes:
           - 1.23.17
-          - 1.24.16
-          - 1.25.12
-          - 1.26.7
-          - 1.27.3
-          - 1.32.2
-          - 1.33.0
+          - 1.32.8
+          - 1.33.10
+          - 1.34.6
+          - 1.35.3
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-go@v4


### PR DESCRIPTION
Stop running integration on older end-of-life versions of Kubernetes
to make room for testing on newer actively maintained versions.