### PR TITLE
[GOG-1908] Make leader-election lease renewal configurable

### DIFF
--- a/cmd/utils/flags.go
+++ b/cmd/utils/flags.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"time"
 
 	"github.com/spotahome/redis-operator/operator/redisfailover"
 	"k8s.io/client-go/util/homedir"
@@ -22,6 +23,9 @@ type CMDFlags struct {
 	K8sQueriesBurstable      int
 	Concurrency              int
 	LogLevel                 string
+	LeaderElectionLeaseDurationSeconds int
+	LeaderElectionRenewDeadlineSeconds int
+	LeaderElectionRetryPeriodSeconds   int
 }
 
 // Init initializes and parse the flags
@@ -38,6 +42,9 @@ func (c *CMDFlags) Init() {
 	// default is 3 for conccurency because kooper also defines 3 as default
 	// reference: https://github.com/spotahome/kooper/blob/master/controller/controller.go#L89
 	flag.IntVar(&c.Concurrency, "concurrency", 3, "Number of conccurent workers meant to process events")
+	flag.IntVar(&c.LeaderElectionLeaseDurationSeconds, "leader-election-lease-duration-seconds", 60, "Leader election lease duration in seconds")
+	flag.IntVar(&c.LeaderElectionRenewDeadlineSeconds, "leader-election-renew-deadline-seconds", 40, "Leader election renew deadline in seconds")
+	flag.IntVar(&c.LeaderElectionRetryPeriodSeconds, "leader-election-retry-period-seconds", 10, "Leader election retry period in seconds")
 	flag.StringVar(&c.LogLevel, "log-level", "info", "set log level")
 	// Parse flags
 	flag.Parse()
@@ -54,5 +61,8 @@ func (c *CMDFlags) ToRedisOperatorConfig() redisfailover.Config {
 		MetricsPath:              c.MetricsPath,
 		Concurrency:              c.Concurrency,
 		SupportedNamespacesRegex: c.SupportedNamespacesRegex,
+		LeaderElectionLeaseDuration: time.Duration(c.LeaderElectionLeaseDurationSeconds) * time.Second,
+		LeaderElectionRenewDeadline: time.Duration(c.LeaderElectionRenewDeadlineSeconds) * time.Second,
+		LeaderElectionRetryPeriod:   time.Duration(c.LeaderElectionRetryPeriodSeconds) * time.Second,
 	}
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -91,6 +91,23 @@ resources:
 
 Take a look at the manifests inside [manifests/kustomize](manifests/kustomize) for more details.
 
+### Leader election configuration
+
+The operator uses a Kubernetes Lease (`redis-failover-lease`) for leader
+election. The renewal cadence is tunable via command-line flags:
+
+| flag | default | description |
+|---|---|---|
+| `-leader-election-lease-duration-seconds` | 60 | How long a lease is valid before non-leaders may take over |
+| `-leader-election-renew-deadline-seconds` | 40 | How long the leader keeps retrying a failed renewal before giving up leadership |
+| `-leader-election-retry-period-seconds` | 10 | How often the leader renews the lease (each renewal is an API write) |
+
+The defaults renew the lease every 10 seconds. Values must satisfy
+`lease duration > renew deadline > retry period`; the operator refuses to start
+otherwise. Longer periods mean fewer Kubernetes API writes (less audit-log
+volume) at the cost of a slower takeover when the leader dies — with a single
+operator replica there is no takeover to wait for, so longer values are safe.
+
 ## Usage
 
 Once the operator is deployed inside a Kubernetes cluster, a new API will be accesible, so you'll be able to create, update and delete redisfailovers.

--- a/operator/redisfailover/config.go
+++ b/operator/redisfailover/config.go
@@ -1,9 +1,14 @@
 package redisfailover
 
+import "time"
+
 // Config is the configuration for the redis operator.
 type Config struct {
-	ListenAddress            string
-	MetricsPath              string
-	Concurrency              int
-	SupportedNamespacesRegex string
+	ListenAddress               string
+	MetricsPath                 string
+	Concurrency                 int
+	SupportedNamespacesRegex    string
+	LeaderElectionLeaseDuration time.Duration
+	LeaderElectionRenewDeadline time.Duration
+	LeaderElectionRetryPeriod   time.Duration
 }

--- a/operator/redisfailover/factory.go
+++ b/operator/redisfailover/factory.go
@@ -2,6 +2,7 @@ package redisfailover
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"regexp"
 	"time"
@@ -27,6 +28,9 @@ const (
 	resync       = 30 * time.Second
 	operatorName = "redis-operator"
 	lockKey      = "redis-failover-lease"
+	defaultLeaderElectionLeaseDuration = 60 * time.Second
+	defaultLeaderElectionRenewDeadline = 40 * time.Second
+	defaultLeaderElectionRetryPeriod   = 10 * time.Second
 )
 
 // New will create an operator that is responsible of managing all the required stuff
@@ -43,8 +47,12 @@ func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lo
 	rfRetriever := NewRedisFailoverRetriever(cfg, k8sService, watchNamespace)
 
 	kooperLogger := kooperlogger{Logger: logger.WithField("operator", "redisfailover")}
+	lockCfg, err := leaderElectionLockConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
 	// Leader election service.
-	leSVC, err := leaderelection.NewDefault(lockKey, lockNamespace, k8sClient, kooperLogger)
+	leSVC, err := leaderelection.New(lockKey, lockNamespace, lockCfg, k8sClient, kooperLogger)
 	if err != nil {
 		return nil, err
 	}
@@ -60,6 +68,36 @@ func New(cfg Config, k8sService k8s.Services, k8sClient kubernetes.Interface, lo
 		ResyncInterval:    resync,
 		ConcurrentWorkers: cfg.Concurrency,
 	})
+}
+
+func leaderElectionLockConfig(cfg Config) (*leaderelection.LockConfig, error) {
+	leaseDuration := cfg.LeaderElectionLeaseDuration
+	if leaseDuration <= 0 {
+		leaseDuration = defaultLeaderElectionLeaseDuration
+	}
+
+	renewDeadline := cfg.LeaderElectionRenewDeadline
+	if renewDeadline <= 0 {
+		renewDeadline = defaultLeaderElectionRenewDeadline
+	}
+
+	retryPeriod := cfg.LeaderElectionRetryPeriod
+	if retryPeriod <= 0 {
+		retryPeriod = defaultLeaderElectionRetryPeriod
+	}
+
+	if leaseDuration <= renewDeadline {
+		return nil, fmt.Errorf("invalid leader election configuration: lease duration (%s) should be greater than renew deadline (%s)", leaseDuration, renewDeadline)
+	}
+	if renewDeadline <= retryPeriod {
+		return nil, fmt.Errorf("invalid leader election configuration: renew deadline (%s) should be greater than retry period (%s)", renewDeadline, retryPeriod)
+	}
+
+	return &leaderelection.LockConfig{
+		LeaseDuration: leaseDuration,
+		RenewDeadline: renewDeadline,
+		RetryPeriod:   retryPeriod,
+	}, nil
 }
 
 func NewRedisFailoverRetriever(cfg Config, cli k8s.Services, watchNamespace string) controller.Retriever {


### PR DESCRIPTION
The leader-election lock config was hardcoded to defaults (15s lease / 10s renew deadline / 2s retry), so every operator instance renewed the redis-failover-lease every 2 seconds.

Across the ~82 instances this generated ~25M lease GET/UPDATE audit events per day — roughly 17.6% of the entire kubernetes-audit index (WTWR-2254). 

With replicas: 1 everywhere, there is no competing candidate and the aggressive conduct buys nothing.

Add three flags backed by leaderelection.New LockConfig:
```
  -leader-election-lease-duration-seconds  (default 60)
  -leader-election-renew-deadline-seconds  (default 40)
  -leader-election-retry-period-seconds    (default 10)
```
with startup validation (lease duration > renew deadline > retry period).

Measured in kind cluster with audit logging:
```
  v4.4.1 (2s renew):        133 events
  this change (10s renew):   26 events
```
This change is built on top of Felipe Peiter's earlier work in the
fix/leader-election branch:
https://github.com/powerhome/redis-operator/commit/e18aa7e2a490a378ede3033cbce099448eaeb939