### PR TITLE
Prepare release v4.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ Also check this project's [releases](https://github.com/powerhome/redis-operator
 
 ## Unreleased
 
+## [v4.5.0] - 2026-08-06
+
+### Changed
+
+- [Make leader-election lease renewal tunable, relax defaults](https://github.com/powerhome/redis-operator/pull/91)
+- [Update Kubernetes testing matrix](https://github.com/powerhome/redis-operator/pull/88)
+
 ## [v4.4.1] - 2026-03-24
 
 ### Fixed

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION := v4.4.1
+VERSION := v4.5.0
 
 # Name of this service/application
 SERVICE_NAME := redis-operator


### PR DESCRIPTION
Prepare the repository for release of version v4.5.0.

This release ships:

- #91 — leader-election lease renewal is now configurable
  (`--leader-elect-lease-duration`, `--leader-elect-renew-deadline`,
  `--leader-elect-retry-period`), with relaxed defaults of 60s/40s/10s and
  upfront validation mirroring client-go (including the 1.2 jitter factor).
- #88 — Kubernetes testing matrix update.

Measured impact of the new defaults: lease renewals drop from ~2s to ~10s intervals